### PR TITLE
method to destroy SparkStreaming and Spark context in factory

### DIFF
--- a/driver/src/main/resources/policies/rabbitMQPolicy.json
+++ b/driver/src/main/resources/policies/rabbitMQPolicy.json
@@ -1,6 +1,7 @@
 {
     "name": "policy-rabbitmq",
     "duration": 10000,
+    "saveRawData": "false",
     "inputs": [
         {
             "name": "in",

--- a/driver/src/main/scala/com/stratio/sparkta/driver/actor/StreamingContextActor.scala
+++ b/driver/src/main/scala/com/stratio/sparkta/driver/actor/StreamingContextActor.scala
@@ -1,11 +1,11 @@
 /**
- * Copyright (C) 2014 Stratio (http://stratio.com)
+ * Copyright (C) 2015 Stratio (http://stratio.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *         http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,10 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.stratio.sparkta.driver.actor
 
 import com.stratio.sparkta.driver.actor.StreamingContextStatusEnum._
 import com.stratio.sparkta.driver.dto.AggregationPoliciesDto
+import com.stratio.sparkta.driver.factory.SparkContextFactory
 import com.stratio.sparkta.driver.service.StreamingContextService
 import org.apache.spark.streaming.StreamingContext
 
@@ -61,9 +63,7 @@ class StreamingContextActor
   override def postStop(): Unit = {
     ssc match {
       case Some(sc: StreamingContext) =>
-        log.debug("Stopping streamingContext with name: " + sc.sparkContext.appName)
-        sc.stop()
-        log.debug("Stopped streamingContext with name: " + sc.sparkContext.appName)
+        SparkContextFactory.destroySparkStreamingContext
       case x => log.warn("Unrecognized StreamingContext to stop!", x)
     }
     super.postStop()

--- a/driver/src/main/scala/com/stratio/sparkta/driver/factory/SparkContextFactory.scala
+++ b/driver/src/main/scala/com/stratio/sparkta/driver/factory/SparkContextFactory.scala
@@ -80,4 +80,18 @@ object SparkContextFactory extends SLF4JLogging {
 
     conf
   }
+
+  def destroySparkStreamingContext: Unit = {
+    synchronized {
+      if (ssc.isDefined) {
+        log.debug("Stopping streamingContext with name: " + ssc.get.sparkContext.appName)
+        ssc.get.stop()
+        log.debug("Stopped streamingContext with name: " + ssc.get.sparkContext.appName)
+        ssc = None
+      }
+      if (sc.isDefined) {
+        sc = None
+      }
+    }
+  }
 }

--- a/driver/src/main/scala/com/stratio/sparkta/driver/factory/SparkContextFactory.scala
+++ b/driver/src/main/scala/com/stratio/sparkta/driver/factory/SparkContextFactory.scala
@@ -86,6 +86,7 @@ object SparkContextFactory extends SLF4JLogging {
       if (ssc.isDefined) {
         log.debug("Stopping streamingContext with name: " + ssc.get.sparkContext.appName)
         ssc.get.stop()
+        ssc.get.awaitTermination()
         log.debug("Stopped streamingContext with name: " + ssc.get.sparkContext.appName)
         ssc = None
       }


### PR DESCRIPTION
#### Description

Bug fixed. Running a policy after a previous deletion was throwing an error.
Method to destroy SparkStreaming and Spark context in factory in orider to creting them a new ones when running a policy
### Reviewer

@sgomezg
## Test

No tests added 
all passed.
## Scalastyle

All test passed.
