### PR TITLE
Support to fragment composition in policies

### DIFF
--- a/doc/src/site/sphinx/usingSparkta.rst
+++ b/doc/src/site/sphinx/usingSparkta.rst
@@ -42,13 +42,14 @@ Aggregation Policy
 
 An aggregation policy it's a JSON document. It's composed of:
 
-* :ref:`Input <input>`: Where is the data coming from?
+* :ref:`Input <input>`: where is the data coming from?
 * :ref:`Output(s) <output>`: aggregate data should be stored?
-* :ref:`Dimension(s) <dimension>`: Which fields will you need for your real-time needs?
-* :ref:`RollUp(s) <rollup>`: How do you want to aggregate the dimensions?
-* :ref:`Transformation(s) <transformation>`: Which functions should be applied before aggregation?
-* :ref:`Save raw data <save-raw>`: Do you want to save raw events?
-* :ref:`Define stateful operations <stateful>`: Do you want to make non associative aggregations?
+* :ref:`Fragment(s) <fragment>`: for convenience you can include alias of inputs/outputs.
+* :ref:`Dimension(s) <dimension>`: which fields will you need for your real-time needs?
+* :ref:`RollUp(s) <rollup>`: how do you want to aggregate the dimensions?
+* :ref:`Transformation(s) <transformation>`: which functions should be applied before aggregation?
+* :ref:`Save raw data <save-raw>`: do you want to save raw events?
+* :ref:`Define stateful operations <stateful>`: do you want to make non associative aggregations?
 
 The policy have a few required fields like *name* and *duration* and others optional, like *saveRawData*, *rawDataParquetPath* and *rawDataGranularity*
 
@@ -106,6 +107,56 @@ Example:
 You can read more specifications for the native outputs plugins here:
   - :doc:`mongodb`
   - :doc:`redis`
+
+
+.. _fragment:
+
+
+Fragment(s)
+-----------
+
+For convenience, it is possible to have an alias about input[s]/output[s] in your policy. These alias are fragments that
+will be included in your policy when the policy has been run.
+
+Fragments have an API Rest to perform CRUD operations over them. For more information you can read documentation about
+it querying Swagger:
+::
+    http://<host>:<port>/swagger#!/fragment
+
+Example:
+
+Let's imagine that you want to use a Twitter's input in some policies but you do not want to write over and over this
+"fragment" in each policy that you made.
+::
+    {
+      "fragmentType": "input",
+      "name": "twitter",
+      "element": {
+        "name": "in-twitter",
+        "elementType": "TwitterInput",
+        "configuration": {
+          "consumerKey": "*****",
+          "consumerSecret": "*****",
+          "accessToken": "*****",
+          "accessTokenSecret": "*****"
+        }
+      }
+    }
+
+Then you can save this fragment in Sparkta:
+::
+    curl -X POST -H "Content-Type: application/json" --data @examples/policiesfragments/twitterExample.json localhost:9090/fragment
+
+Now you can include this fragment in every policy that has Twitter as input in a simple and comprehensible way:
+::
+    "fragments": [
+    {
+      "name": "twitter",
+      "fragmentType": "input",
+    }
+  ]
+
+You can include as many fragments as you need. Easy, Right?
 
 .. _dimension:
 

--- a/driver/src/main/scala/com/stratio/sparkta/driver/actor/PolicyControllerActor.scala
+++ b/driver/src/main/scala/com/stratio/sparkta/driver/actor/PolicyControllerActor.scala
@@ -51,12 +51,12 @@ class PolicyControllerActor(val streamingSupervisor: ActorRef, val fragmentSuper
 
   val policyRoute = new PolicyHttpService {
     override val supervisor: ActorRef = streamingSupervisor
-    def actorRefFactory: ActorRefFactory = actorRefFactory
+    override implicit def actorRefFactory: ActorRefFactory = context
   }
 
   val fragmentRoute = new FragmentHttpService {
     override val supervisor: ActorRef = fragmentSupervisor
-    override implicit def actorRefFactory: ActorRefFactory = actorRefFactory
+    override implicit def actorRefFactory: ActorRefFactory = context
   }
 
   def receive: Receive = runRoute(handleExceptions(exceptionHandler)(

--- a/driver/src/main/scala/com/stratio/sparkta/driver/dto/AggregationPoliciesDto.scala
+++ b/driver/src/main/scala/com/stratio/sparkta/driver/dto/AggregationPoliciesDto.scala
@@ -43,7 +43,8 @@ case class AggregationPoliciesDto(name: String = "default",
                                   operators: Seq[PolicyElementDto],
                                   inputs: Seq[PolicyElementDto],
                                   parsers: Seq[PolicyElementDto],
-                                  outputs: Seq[PolicyElementDto])
+                                  outputs: Seq[PolicyElementDto],
+                                  fragments: Seq[FragmentElementDto])
 
 case object AggregationPoliciesDto {
   val StreamingWindowDurationInMillis = 2000

--- a/driver/src/main/scala/com/stratio/sparkta/driver/dto/FragmentElementDto.scala
+++ b/driver/src/main/scala/com/stratio/sparkta/driver/dto/FragmentElementDto.scala
@@ -24,3 +24,11 @@ package com.stratio.sparkta.driver.dto
  * @author anistal
  */
 case class FragmentElementDto(fragmentType: String, name: String, element: PolicyElementDto)
+
+
+object FragmentType extends Enumeration {
+  type FragmentType = Value
+  val input = Value("input")
+  val output = Value("output")
+  val AllowedTypes = Seq(input, output)
+}

--- a/driver/src/main/scala/com/stratio/sparkta/driver/helpers/PolicyHelper.scala
+++ b/driver/src/main/scala/com/stratio/sparkta/driver/helpers/PolicyHelper.scala
@@ -1,0 +1,47 @@
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permis;sions and
+ * limitations under the License.
+ */
+
+package com.stratio.sparkta.driver.helpers
+
+import com.stratio.sparkta.driver.dto.FragmentType._
+import com.stratio.sparkta.driver.dto.{AggregationPoliciesDto, FragmentType, PolicyElementDto}
+
+/**
+ * Helper with operations over policies and policy fragments.
+ * @author anistal
+ */
+object PolicyHelper {
+
+  /**
+   * If the policy has fragments, it tries to parse them and depending of its type it composes input/outputs/etc.
+   * @param apConfig with the policy.
+   * @return a parsed policy with fragments included in input/outputs.
+   */
+  def parseFragments(apConfig: AggregationPoliciesDto): AggregationPoliciesDto = {
+    val mapInputsOutputs: Map[FragmentType, Seq[PolicyElementDto]] = (apConfig.fragments.map(fragment =>
+      FragmentType.withName(fragment.fragmentType) match {
+        case FragmentType.input => (FragmentType.input -> fragment.element)
+        case FragmentType.output => (FragmentType.output -> fragment.element)
+      })
+      ++ apConfig.inputs.map(input => (FragmentType.input -> input))
+      ++ apConfig.outputs.map(output => (FragmentType.output -> output))
+      ).groupBy(_._1).mapValues(_.map(_._2))
+
+    apConfig.copy(
+      inputs = mapInputsOutputs.get(FragmentType.input).getOrElse(Seq()),
+      outputs = mapInputsOutputs.get(FragmentType.output).getOrElse(Seq()))
+  }
+}

--- a/driver/src/test/scala/com/stratio/sparkta/driver/test/dto/AggregationPoliciesDtoSpec.scala
+++ b/driver/src/test/scala/com/stratio/sparkta/driver/test/dto/AggregationPoliciesDtoSpec.scala
@@ -57,7 +57,8 @@ with Matchers {
         Seq(mock[PolicyElementDto]),
         Seq(input),
         Seq(mock[PolicyElementDto]),
-        Seq(mock[PolicyElementDto]))
+        Seq(mock[PolicyElementDto]),
+        Seq(mock[FragmentElementDto]))
 
       val test = AggregationPoliciesValidator.validateDto(apd)
 

--- a/driver/src/test/scala/com/stratio/sparkta/driver/test/helpers/PolicyHelperSpec.scala
+++ b/driver/src/test/scala/com/stratio/sparkta/driver/test/helpers/PolicyHelperSpec.scala
@@ -1,0 +1,69 @@
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.stratio.sparkta.driver.test.helpers
+
+import com.stratio.sparkta.driver.dto.{AggregationPoliciesDto, FragmentElementDto, PolicyElementDto}
+import com.stratio.sparkta.driver.helpers.PolicyHelper
+import org.junit.runner.RunWith
+import org.scalatest._
+import org.scalatest.junit.JUnitRunner
+
+/**
+ * Tests over policy operations.
+ * @author anistal
+ */
+@RunWith(classOf[JUnitRunner])
+class PolicyHelperSpec extends FeatureSpec with GivenWhenThen with Matchers {
+  feature("A policy that contains fragments must parse these fragments and join them to input/outputs depending of " +
+    "its type") {
+    Given("a policy with an input, an output and a fragment with an input")
+    val ap = new AggregationPoliciesDto(
+      dimensions = Seq(),
+      rollups = Seq(),
+      operators =  Seq(),
+      inputs = Seq(
+        PolicyElementDto("input1","input",Map())),
+      parsers =  Seq(),
+      outputs =  Seq(
+        PolicyElementDto("output1","output",Map())),
+      fragments = Seq(
+        FragmentElementDto(
+          name="fragment1",
+          fragmentType="input",
+          element = PolicyElementDto("inputF","input", Map())),
+        FragmentElementDto(
+          name="fragment1",
+          fragmentType="output",
+          element = PolicyElementDto("outputF","output", Map()))
+      )
+    )
+
+    When("the helper parse these fragments")
+    val result = PolicyHelper.parseFragments(ap)
+
+    Then("inputs/outputs must have the existing input/outputs and the parsed input fragment")
+    result.inputs.toSet should equal(Seq(
+      PolicyElementDto("input1","input",Map()),
+      PolicyElementDto("inputF","input",Map())).toSet
+    )
+
+    result.outputs.toSet should equal(Seq(
+      PolicyElementDto("output1","output",Map()),
+      PolicyElementDto("outputF","output",Map())).toSet
+    )
+  }
+}

--- a/driver/src/test/scala/com/stratio/sparkta/driver/test/route/PolicyRoutesSpec.scala
+++ b/driver/src/test/scala/com/stratio/sparkta/driver/test/route/PolicyRoutesSpec.scala
@@ -81,7 +81,7 @@ with Matchers {
       val PolicyName = "p-1"
       val apd = new AggregationPoliciesDto(PolicyName, "false", "myPath","day",
         checkpointDir, "", checkpointGranularity, checkpointInterval, checkpointAvailable, 0,
-        Seq(), Seq(), Seq(), Seq(), Seq(), Seq())
+        Seq(), Seq(), Seq(), Seq(), Seq(), Seq(), Seq())
       try {
         val test = Post("/policy", apd) ~> routes
         supervisorProbe.expectMsg(new CreateContext(apd))
@@ -113,7 +113,7 @@ with Matchers {
       val apd =
         new AggregationPoliciesDto(PolicyName, "true", "example","day",
           checkpointDir, "", checkpointGranularity, checkpointInterval, checkpointAvailable, 0,
-          Seq(dimensionDto), Seq(rollupDto), Seq(), Seq(), Seq(), Seq())
+          Seq(dimensionDto), Seq(rollupDto), Seq(), Seq(), Seq(), Seq(), Seq())
       val test = Post("/policy", apd) ~> routes
       test ~> check {
         rejections.size should be(1)

--- a/examples/policies/ITwitter-OPrintWithFragments.json
+++ b/examples/policies/ITwitter-OPrintWithFragments.json
@@ -1,0 +1,183 @@
+{
+  "name": "policy-Twitter-Print",
+  "duration": 10000,
+  "saveRawData": "false",
+  "rawDataParquetPath": "myTestParquetPath",
+  "checkpointDir": "checkpoint",
+  "timeBucket": "minute",
+  "checkpointGranularity": "minute",
+  "checkpointInterval": 30000,
+  "checkpointTimeAvailability": 60000,
+
+  "fragments": [
+    {
+      "fragmentType": "input",
+      "name": "twitter",
+      "element": null
+    }
+  ],
+
+  "dimensions": [
+    {
+      "dimensionType": "TwitterStatusBucketer",
+      "name": "status"
+    },
+    {
+      "dimensionType": "PassthroughBucketer",
+      "name": "userLocation"
+    },
+    {
+      "dimensionType": "PassthroughBucketer",
+      "name": "wordsN"
+    },
+    {
+      "dimensionType": "DateTimeBucketer",
+      "name": "timestamp"
+    },
+    {
+      "dimensionType": "GeoHashBucketer",
+      "name": "geolocation"
+    }
+  ],
+  "rollups": [
+    {
+      "dimensionAndBucketTypes": [
+        {
+          "dimensionName": "status",
+          "bucketType": "hastags"
+        },
+        {
+          "dimensionName": "status",
+          "bucketType": "firsthastag"
+        },
+        {
+          "dimensionName": "status",
+          "bucketType": "urls"
+        },
+        {
+          "dimensionName": "status",
+          "bucketType": "retweets"
+        },
+        {
+          "dimensionName": "geolocation",
+          "bucketType": "precision3"
+        },
+        {
+          "dimensionName": "timestamp",
+          "bucketType": "minute"
+        }
+      ],
+      "operators": ["count-operator","sum-operator","max-operator","min-operator","range-operator","avg-operator",
+        "median-operator",
+        "variance-operator","stddev-operator","fullText-operator","lastValue-operator","firstValue-operator","accumulator-operator"]
+    }
+  ],
+  "outputs": [
+    {
+      "name": "out-print",
+      "elementType": "PrintOutput",
+      "configuration": {
+        "multiplexer": "true",
+        "isAutoCalculateId": "true"
+      }
+    }
+  ],
+  "operators": [
+    {
+      "name": "count-operator",
+      "elementType": "CountOperator",
+      "configuration": {}
+    },
+    {
+      "name": "count-distinct-operator",
+      "elementType": "CountOperator",
+      "configuration": {
+        "distinctFields": "wordsN"
+      }
+    },
+    {
+      "name": "sum-operator",
+      "elementType": "SumOperator",
+      "configuration": {
+        "inputField": "wordsN"
+      }
+    },
+    {
+      "name": "max-operator",
+      "elementType": "MaxOperator",
+      "configuration": {
+        "inputField": "wordsN"
+      }
+    },
+    {
+      "name": "min-operator",
+      "elementType": "MinOperator",
+      "configuration": {
+        "inputField": "wordsN"
+      }
+    },
+    {
+      "name": "range-operator",
+      "elementType": "RangeOperator",
+      "configuration": {
+        "inputField": "wordsN"
+      }
+    },
+    {
+      "name": "avg-operator",
+      "elementType": "AvgOperator",
+      "configuration": {
+        "inputField": "wordsN"
+      }
+    },
+    {
+      "name": "median-operator",
+      "elementType": "MedianOperator",
+      "configuration": {
+        "inputField": "wordsN"
+      }
+    },
+    {
+      "name": "variance-operator",
+      "elementType": "VarianceOperator",
+      "configuration": {
+        "inputField": "wordsN"
+      }
+    },
+    {
+      "name": "stddev-operator",
+      "elementType": "StddevOperator",
+      "configuration": {
+        "inputField": "wordsN"
+      }
+    },
+    {
+      "name": "fullText-operator",
+      "elementType": "FullTextOperator",
+      "configuration": {
+        "inputField": "userLocation"
+      }
+    },
+    {
+      "name": "lastValue-operator",
+      "elementType": "LastValueOperator",
+      "configuration": {
+        "inputField": "retweets"
+      }
+    },
+    {
+      "name": "firstValue-operator",
+      "elementType": "FirstValueOperator",
+      "configuration": {
+        "inputField": "retweets"
+      }
+    },
+    {
+      "name": "accumulator-operator",
+      "elementType": "AccumulatorOperator",
+      "configuration": {
+        "inputField": "wordsN"
+      }
+    }
+  ]
+}

--- a/examples/policies/detector.json
+++ b/examples/policies/detector.json
@@ -1,0 +1,162 @@
+{
+  "name": "policy-kafka",
+  "duration": 2000,
+  "saveRawData": "false",
+  "rawDataParquetPath": "myTestParquetPath",
+  "inputs": [
+    {
+      "name": "in-kafka",
+      "elementType": "KafkaInput",
+      "configuration": {
+        "topics": "detectorStream3",
+        "kafkaParams.zookeeper.connect": "*****",
+        "kafkaParams.group.id": "kafka-pruebas-8",
+        "storageLevel": "MEMORY_AND_DISK_SER_2"
+      }
+    }
+  ],
+  "dimensions": [
+    {
+      "dimensionType": "PassthroughBucketer",
+      "name": "company_root"
+    },
+    {
+      "dimensionType": "PassthroughBucketer",
+      "name": "ou_vehicle"
+    },
+    {
+      "dimensionType": "PassthroughBucketer",
+      "name": "asset"
+    },
+    {
+      "dimensionType": "DateTimeBucketer",
+      "name": "recorded_at_ms"
+    },
+    {
+      "dimensionType": "GeoHashBucketer",
+      "name": "geo"
+    },
+    {
+      "dimensionType": "PassthroughBucketer",
+      "name": "rpm_event_avg"
+    },
+    {
+      "dimensionType": "PassthroughBucketer",
+      "name": "odometer"
+    },
+    {
+      "dimensionType": "PassthroughBucketer",
+      "name": "odometerNum"
+    },
+    {
+      "dimensionType": "PassthroughBucketer",
+      "name": "rpmAvgNum"
+    },
+    {
+      "dimensionType": "PassthroughBucketer",
+      "name": "path_id"
+    }
+  ],
+  "rollups": [
+    {
+      "dimensionAndBucketTypes": [
+        {
+          "dimensionName": "company_root",
+          "bucketType": "identity"
+        },
+        {
+          "dimensionName": "ou_vehicle",
+          "bucketType": "identity"
+        },
+        {
+          "dimensionName": "geo",
+          "bucketType": "precision12"
+        },
+        {
+          "dimensionName": "recorded_at_ms",
+          "bucketType": "minute"
+        }
+      ],
+      "operators": ["avg-operator"]
+    },
+    {
+      "dimensionAndBucketTypes": [
+        {
+          "dimensionName": "company_root",
+          "bucketType": "identity"
+        },
+        {
+          "dimensionName": "ou_vehicle",
+          "bucketType": "identity"
+        },
+        {
+          "dimensionName": "asset",
+          "bucketType": "identity"
+        },
+        {
+          "dimensionName": "recorded_at_ms",
+          "bucketType": "minute"
+        },
+        {
+          "dimensionName": "path_id",
+          "bucketType": "identity"
+        }
+      ],
+
+      "operators": ["max-operator", "min-operator"]
+    }
+  ],
+  "operators": [
+    {
+      "name": "avg-operator",
+      "elementType": "AvgOperator",
+      "configuration": {
+        "inputField": "rpmAvgNum"
+      }
+    },
+    {
+      "name": "max-operator",
+      "elementType": "MaxOperator",
+      "configuration": {
+        "inputField": "odometerNum"
+      }
+    },
+    {
+      "name": "min-operator",
+      "elementType": "MinOperator",
+      "configuration": {
+        "inputField": "odometerNum"
+      }
+    }
+  ],
+
+  "outputs": [
+    {
+      "name": "out-mongo",
+      "elementType": "MongoDbOutput",
+      "configuration": {
+        "clientUri": "mongodb://localhost:27017",
+        "dbName": "sparkta3",
+        "multiplexer": "false",
+        "granularity": "minute",
+	    "identitiesSaved": "true"
+      }
+    }
+  ],
+
+  "parsers": [
+    {
+      "name": "detector-parser",
+      "elementType": "DetectorParser",
+      "configuration": {
+      }
+    },
+    {
+      "name": "recorded_at_ms-parser",
+      "elementType": "DateTimeParser",
+      "configuration": {
+        "recorded_at_ms": "unixMillis"
+      }
+    }
+  ]
+}

--- a/examples/policies/fragments/twitterFragment.json
+++ b/examples/policies/fragments/twitterFragment.json
@@ -1,0 +1,14 @@
+{
+  "fragmentType": "input",
+  "name": "twitter",
+  "element": {
+    "name": "in-twitter",
+    "elementType": "TwitterInput",
+    "configuration": {
+      "consumerKey": "*****",
+      "consumerSecret": "*****",
+      "accessToken": "*****",
+      "accessTokenSecret": "*****"
+    }		
+  }
+}


### PR DESCRIPTION
**Description**
From a saved fragment stored in ZK, it is possible to composite a policy that includes these fragments with inputs/outputs.

To create a fragment in ZK:
curl -X POST -H "Content-Type: application/json" --data @examples/policies/fragments/fragmentTwitter.json localhost:9090/fragment

Now you can use this example policy to test that a policy with fragments is created correctly:

curl -X POST -H "Content-Type: application/json" --data @examples/policies/ITwitter-OPrintWithFragments.json localhost:9090/policies

**Reviewer**
@sgomezg 

**Test**
Some modifications in existing tests.
This PR has a fourth part that will include a deep testing.

**Scalastyle**
All test passed.
