### PR TITLE
SPARKTA-198 add input/outputs when a policy is submitted

### DIFF
--- a/serving-api/src/main/scala/com/stratio/sparkta/serving/api/actor/ControllerActor.scala
+++ b/serving-api/src/main/scala/com/stratio/sparkta/serving/api/actor/ControllerActor.scala
@@ -45,7 +45,7 @@ with SparktaSerializer {
         requestUri { uri =>
           log.error(exception.getLocalizedMessage, exception)
           complete(StatusCodes.InternalServerError, write(
-            new ErrorModel(ErrorModel.CodeUnknow, exception.getLocalizedMessage)
+            new ErrorModel(ErrorModel.CodeUnknown, exception.getLocalizedMessage)
           ))
         }
     }

--- a/serving-api/src/main/scala/com/stratio/sparkta/serving/api/actor/PolicyActor.scala
+++ b/serving-api/src/main/scala/com/stratio/sparkta/serving/api/actor/PolicyActor.scala
@@ -87,7 +87,7 @@ class PolicyActor(curatorFramework: CuratorFramework, policyStatusActor: ActorRe
       byId(id)
     }).recover {
       case e: NoNodeException => throw new ServingCoreException(ErrorModel.toString(
-        new ErrorModel(ErrorModel.CodeNotExistsPolicytWithId, s"No policy with id $id.")
+        new ErrorModel(ErrorModel.CodeNotExistsPolicyWithId, s"No policy with id $id.")
       ))
     })
 
@@ -101,10 +101,10 @@ class PolicyActor(curatorFramework: CuratorFramework, policyStatusActor: ActorRe
         byId(element)).filter(policy => policy.name == name).head
     }).recover {
       case e: NoNodeException => throw new ServingCoreException(ErrorModel.toString(
-        new ErrorModel(ErrorModel.CodeNotExistsPolicytWithName, s"No policy with name $name.")
+        new ErrorModel(ErrorModel.CodeNotExistsPolicyWithName, s"No policy with name $name.")
       ))
       case e: NoSuchElementException => throw new ServingCoreException(ErrorModel.toString(
-        new ErrorModel(ErrorModel.CodeNotExistsPolicytWithName, s"No policy with name $name.")
+        new ErrorModel(ErrorModel.CodeNotExistsPolicyWithName, s"No policy with name $name.")
       ))
     })
 
@@ -117,7 +117,7 @@ class PolicyActor(curatorFramework: CuratorFramework, policyStatusActor: ActorRe
       val searchPolicy = existsByNameId(policy.name)
       if (searchPolicy.isDefined) {
         throw new ServingCoreException(ErrorModel.toString(
-          new ErrorModel(ErrorModel.CodeExistsPolicytWithName,
+          new ErrorModel(ErrorModel.CodeExistsPolicyWithName,
             s"Policy with name ${policy.name} exists. The actual policty id is: ${searchPolicy.get.id}")
         ))
       }
@@ -137,7 +137,7 @@ class PolicyActor(curatorFramework: CuratorFramework, policyStatusActor: ActorRe
       val searchPolicy = existsByNameId(policy.name, policy.id)
       if (searchPolicy.isEmpty) {
         throw new ServingCoreException(ErrorModel.toString(
-          new ErrorModel(ErrorModel.CodeExistsPolicytWithName,
+          new ErrorModel(ErrorModel.CodeExistsPolicyWithName,
             s"Policy with name ${policy.name} not exists.")
         ))
       } else {
@@ -149,7 +149,7 @@ class PolicyActor(curatorFramework: CuratorFramework, policyStatusActor: ActorRe
       }
     }).recover {
       case e: NoNodeException => throw new ServingCoreException(ErrorModel.toString(
-        new ErrorModel(ErrorModel.CodeNotExistsPolicytWithId, s"No policy with id ${policy.id.get}.")
+        new ErrorModel(ErrorModel.CodeNotExistsPolicyWithId, s"No policy with id ${policy.id.get}.")
       ))
     })
   }

--- a/serving-api/src/main/scala/com/stratio/sparkta/serving/api/actor/SwaggerActor.scala
+++ b/serving-api/src/main/scala/com/stratio/sparkta/serving/api/actor/SwaggerActor.scala
@@ -50,7 +50,7 @@ class SwaggerActor(actorsMap: Map[String, ActorRef], curatorFramework : CuratorF
         requestUri { uri =>
           log.error(exception.getLocalizedMessage, exception)
           complete(StatusCodes.InternalServerError, write(
-            new ErrorModel(ErrorModel.CodeUnknow, exception.getLocalizedMessage)
+            new ErrorModel(ErrorModel.CodeUnknown, exception.getLocalizedMessage)
           ))
         }
     }

--- a/serving-api/src/main/scala/com/stratio/sparkta/serving/api/actor/TemplateActor.scala
+++ b/serving-api/src/main/scala/com/stratio/sparkta/serving/api/actor/TemplateActor.scala
@@ -54,7 +54,7 @@ class TemplateActor extends Actor with Json4sJacksonSupport with SLF4JLogging wi
       read[TemplateModel](getInputStreamFromResource(s"templates/${t}/${name.toLowerCase}.json"))
     }).recover {
       case e: NullPointerException => throw new ServingCoreException(ErrorModel.toString(
-        new ErrorModel(ErrorModel.CodeNotExistsTemplatetWithName, s"No template of type $t  with name ${name}.json")
+        new ErrorModel(ErrorModel.CodeNotExistsTemplateWithName, s"No template of type $t  with name ${name}.json")
       ))
     })
 

--- a/serving-api/src/main/scala/com/stratio/sparkta/serving/api/service/handler/CustomExceptionHandler.scala
+++ b/serving-api/src/main/scala/com/stratio/sparkta/serving/api/service/handler/CustomExceptionHandler.scala
@@ -45,7 +45,7 @@ with SparktaSerializer {
         requestUri { uri =>
           log.error(exception.getLocalizedMessage, exception)
           complete((StatusCodes.InternalServerError, write(
-            new ErrorModel(ErrorModel.CodeUnknow, Option(exception.getLocalizedMessage).getOrElse("unknown"))
+            new ErrorModel(ErrorModel.CodeUnknown, Option(exception.getLocalizedMessage).getOrElse("unknown"))
           )))
         }
     }

--- a/serving-api/src/main/scala/com/stratio/sparkta/serving/api/service/http/AppStatusHttpService.scala
+++ b/serving-api/src/main/scala/com/stratio/sparkta/serving/api/service/http/AppStatusHttpService.scala
@@ -45,7 +45,7 @@ trait AppStatusHttpService extends BaseHttpService {
         complete {
           if (!curatorInstance.getZookeeperClient.getZooKeeper.getState.isConnected)
             throw new ServingCoreException(ErrorModel.toString(
-              new ErrorModel(ErrorModel.CodeUnknow, s"Zk isn't connected at" +
+              new ErrorModel(ErrorModel.CodeUnknown, s"Zk isn't connected at" +
                 s" ${curatorInstance.getZookeeperClient.getCurrentConnectionString}.")
             ))
           else "OK"

--- a/serving-api/src/main/scala/com/stratio/sparkta/serving/api/service/http/PolicyContextHttpService.scala
+++ b/serving-api/src/main/scala/com/stratio/sparkta/serving/api/service/http/PolicyContextHttpService.scala
@@ -1,24 +1,26 @@
 /**
-  * Copyright (C) 2016 Stratio (http://stratio.com)
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  * http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-  */
+ * Copyright (C) 2016 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 package com.stratio.sparkta.serving.api.service.http
 
+import akka.actor.ActorRef
 import akka.pattern.ask
 import com.stratio.sparkta.serving.api.actor.SparkStreamingContextActor._
 import com.stratio.sparkta.serving.api.constants.HttpConstant
+import com.stratio.sparkta.serving.core.actor.FragmentActor
 import com.stratio.sparkta.serving.core.constants.AkkaConstant
 import com.stratio.sparkta.serving.core.exception.ServingCoreException
 import com.stratio.sparkta.serving.core.helpers.PolicyHelper
@@ -28,7 +30,7 @@ import com.wordnik.swagger.annotations._
 import spray.http.{HttpResponse, StatusCodes}
 import spray.routing._
 
-import scala.concurrent.Await
+import scala.concurrent.{Future, Await}
 import scala.util.{Failure, Success, Try}
 
 @Api(value = HttpConstant.PolicyContextPath, description = "Operations about policy contexts.", position = 0)
@@ -81,7 +83,7 @@ trait PolicyContextHttpService extends BaseHttpService {
                 HttpResponse(StatusCodes.Created)
               else
                 throw new ServingCoreException(ErrorModel.toString(
-                  ErrorModel(ErrorModel.CodeNotExistsPolicytWithId,
+                  ErrorModel(ErrorModel.CodeNotExistsPolicyWithId,
                     s"No policy with id ${policyStatus.id}.")
                 ))
             }
@@ -110,16 +112,22 @@ trait PolicyContextHttpService extends BaseHttpService {
         entity(as[AggregationPoliciesModel]) { p =>
           val parsedP = getPolicyWithFragments(p)
           val isValidAndMessageTuple = AggregationPoliciesValidator.validateDto(parsedP)
-
+          val fragmentActor: ActorRef = actors.getOrElse(AkkaConstant.FragmentActor, throw new ServingCoreException
+          (ErrorModel.toString(ErrorModel(ErrorModel.CodeUnknown, s"Error getting fragmentActor"))))
           validate(isValidAndMessageTuple._1, isValidAndMessageTuple._2) {
             complete {
               for {
-                response <- (supervisor ? Create(parsedP)).mapTo[Try[AggregationPoliciesModel]]
+                policyResponseTry <- (supervisor ? Create(parsedP)).mapTo[Try[AggregationPoliciesModel]]
               } yield {
-                response match {
+                policyResponseTry match {
                   case Success(policy) =>
+                    val inputs = PolicyHelper.populateFragmentFromPolicy(policy, FragmentType.input)
+                    val outputs = PolicyHelper.populateFragmentFromPolicy(policy, FragmentType.output)
+                    createFragments(fragmentActor, outputs.toList ::: inputs.toList)
                     PolicyResult(policy.id.getOrElse(""), p.name)
-                  case Failure(e) => throw e
+                  case Failure(ex: Throwable) => throw new ServingCoreException(ErrorModel.toString(
+                    ErrorModel(ErrorModel.CodeErrorCreatingPolicy, s"Can't create policy")
+                  ))
                 }
               }
             }
@@ -127,6 +135,10 @@ trait PolicyContextHttpService extends BaseHttpService {
         }
       }
     }
+  }
+
+  def createFragments(fragmentActor: ActorRef, fragments: Seq[FragmentElementModel]): Unit = {
+    fragments.foreach(fragment => fragmentActor ! FragmentActor.Create(fragment))
   }
 
   def getPolicyWithFragments(policy: AggregationPoliciesModel): AggregationPoliciesModel =

--- a/serving-api/src/test/scala/com/stratio/sparkta/serving/api/actor/TemplateActorTest.scala
+++ b/serving-api/src/test/scala/com/stratio/sparkta/serving/api/actor/TemplateActorTest.scala
@@ -70,7 +70,7 @@ with MockitoSugar with SparktaSerializer {
 
     val ServingException = new ServingCoreException(
       ErrorModel.toString(
-        new ErrorModel(ErrorModel.CodeNotExistsTemplatetWithName,
+        new ErrorModel(ErrorModel.CodeNotExistsTemplateWithName,
           "No template of type input  with name templateName.json")))
 
     val templateModel = read[TemplateModel](templateModelJson)

--- a/serving-core/src/main/scala/com/stratio/sparkta/serving/core/helpers/PolicyHelper.scala
+++ b/serving-core/src/main/scala/com/stratio/sparkta/serving/core/helpers/PolicyHelper.scala
@@ -1,18 +1,18 @@
 /**
- * Copyright (C) 2016 Stratio (http://stratio.com)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+  * Copyright (C) 2016 Stratio (http://stratio.com)
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
 
 package com.stratio.sparkta.serving.core.helpers
 
@@ -27,15 +27,16 @@ import scala.concurrent.Await
 import scala.util.{Failure, Success}
 
 /**
- * Helper with operations over policies and policy fragments.
- */
+  * Helper with operations over policies and policy fragments.
+  */
 object PolicyHelper {
 
   /**
-   * If the policy has fragments, it tries to parse them and depending of its type it composes input/outputs/etc.
-   * @param apConfig with the policy.
-   * @return a parsed policy with fragments included in input/outputs.
-   */
+    * If the policy has fragments, it tries to parse them and depending of its type it composes input/outputs/etc.
+    *
+    * @param apConfig with the policy.
+    * @return a parsed policy with fragments included in input/outputs.
+    */
   def parseFragments(apConfig: AggregationPoliciesModel): AggregationPoliciesModel = {
 
     val fragmentInputs = getFragmentFromType(apConfig.fragments, FragmentType.input)
@@ -47,11 +48,12 @@ object PolicyHelper {
   }
 
   /**
-   * The policy only has fragments with its name and type. When this method is called it finds the full fragment in
-   * ZK and fills the rest of the fragment.
-   * @param apConfig with the policy.
-   * @return a fragment with all fields filled.
-   */
+    * The policy only has fragments with its name and type. When this method is called it finds the full fragment in
+    * ZK and fills the rest of the fragment.
+    *
+    * @param apConfig with the policy.
+    * @return a fragment with all fields filled.
+    */
   def fillFragments(apConfig: AggregationPoliciesModel,
                     actor: ActorRef,
                     currentTimeout: Timeout): AggregationPoliciesModel = {
@@ -67,6 +69,19 @@ object PolicyHelper {
     apConfig.copy(fragments = currentFragments)
   }
 
+  /**
+    * This method tries to parse an input/output from a policy to a FragmentModelElement
+    *
+    * @param policy       AggregationPolicy to parse from
+    * @param fragmentType type of fragment to parse to
+    * @return a valid fragment element (input/output)
+    */
+  def populateFragmentFromPolicy(policy: AggregationPoliciesModel, fragmentType: `type`): Seq[FragmentElementModel] =
+    fragmentType match {
+      case FragmentType.input => Seq(policy.input.get.parseToFragment(fragmentType))
+      case FragmentType.output => policy.outputs.map(output => output.parseToFragment(fragmentType))
+    }
+
   //////////////////////////////////////////// PRIVATE METHODS /////////////////////////////////////////////////////////
 
   private def getFragmentFromType(fragments: Seq[FragmentElementModel], fragmentType: `type`)
@@ -76,11 +91,12 @@ object PolicyHelper {
   }
 
   /**
-   * Depending of where is the input it tries to get a input. If not an exceptions is thrown.
-   * @param fragmentsInputs with inputs extracted from the fragments.
-   * @param inputs with the current configuration.
-   * @return A policyElementModel with the input.
-   */
+    * Depending of where is the input it tries to get a input. If not an exceptions is thrown.
+    *
+    * @param fragmentsInputs with inputs extracted from the fragments.
+    * @param inputs          with the current configuration.
+    * @return A policyElementModel with the input.
+    */
   private def getCurrentInput(fragmentsInputs: Seq[PolicyElementModel],
                               inputs: Option[PolicyElementModel]): PolicyElementModel = {
 

--- a/serving-core/src/main/scala/com/stratio/sparkta/serving/core/models/ErrorModel.scala
+++ b/serving-core/src/main/scala/com/stratio/sparkta/serving/core/models/ErrorModel.scala
@@ -38,11 +38,12 @@ object ErrorModel extends SparktaSerializer{
   val CodeExistsFragmentWithName      = "100"
   val CodeNotExistsFragmentWithId     = "101"
   val CodeNotExistsFragmentWithName   = "102"
-  val CodeExistsPolicytWithName       = "200"
-  val CodeNotExistsPolicytWithId      = "201"
-  val CodeNotExistsPolicytWithName    = "202"
-  val CodeNotExistsTemplatetWithName  = "300"
-  val CodeUnknow                      = "666"
+  val CodeExistsPolicyWithName        = "200"
+  val CodeNotExistsPolicyWithId       = "201"
+  val CodeNotExistsPolicyWithName     = "202"
+  val CodeErrorCreatingPolicy         = "203"
+  val CodeNotExistsTemplateWithName   = "300"
+  val CodeUnknown                     = "666"
 
   def toString(errorModel: ErrorModel): String = {
     write(errorModel)

--- a/serving-core/src/main/scala/com/stratio/sparkta/serving/core/models/FragmentElementModel.scala
+++ b/serving-core/src/main/scala/com/stratio/sparkta/serving/core/models/FragmentElementModel.scala
@@ -16,8 +16,11 @@
 
 package com.stratio.sparkta.serving.core.models
 
+import com.stratio.sparkta.serving.core.exception.ServingCoreException
+
 /**
  * A fragmentElementDto represents a piece of policy that will be composed with other fragments before.
+ *
  * @param fragmentType that could be inputs/outputs/parsers
  * @param name that will be used as an identifier of the fragment.
  * @param element with all config parameters of the fragment.
@@ -28,7 +31,17 @@ case class FragmentElementModel(id: Option[String] = None,
                                 name: String,
                                 description: String,
                                 shortDescription: String,
-                                element:PolicyElementModel)
+                                element:PolicyElementModel){
+
+  def getIdIfEquals: (FragmentElementModel) => Option[String] = {
+    currentFragment => this.equals(currentFragment) match {
+      case true => currentFragment.id
+      case false => throw new ServingCoreException(ErrorModel.toString(
+        new ErrorModel(ErrorModel.CodeExistsFragmentWithName,
+          s"Fragment of type ${this.fragmentType} with name ${this.name} exists.")))
+    }
+  }
+}
 
 object FragmentType extends Enumeration {
   type `type` = Value

--- a/serving-core/src/main/scala/com/stratio/sparkta/serving/core/models/PolicyElementModel.scala
+++ b/serving-core/src/main/scala/com/stratio/sparkta/serving/core/models/PolicyElementModel.scala
@@ -1,25 +1,36 @@
 /**
- * Copyright (C) 2016 Stratio (http://stratio.com)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+  * Copyright (C) 2016 Stratio (http://stratio.com)
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  * http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
 
 package com.stratio.sparkta.serving.core.models
 
 import com.stratio.sparkta.sdk.JsoneyString
 import com.stratio.sparkta.serving.core.constants.AppConstant
+import com.stratio.sparkta.serving.core.models.FragmentType.`type`
 
 case class PolicyElementModel(name: String, `type`: String, configuration: Map[String, JsoneyString] = Map()) {
 
   val jarFile = AppConstant.jarsFilesMap.get(`type`)
+
+  def parseToFragment(fragmentType: `type`): FragmentElementModel = {
+    FragmentElementModel(
+      id = None,
+      fragmentType = fragmentType.toString,
+      name = name,
+      description = "",
+      shortDescription = "",
+      element = this)
+  }
 }

--- a/testsAT/src/test/java/com/stratio/sparta/testsAT/automated/gui/policies/AddAutoFragmentCreation.java
+++ b/testsAT/src/test/java/com/stratio/sparta/testsAT/automated/gui/policies/AddAutoFragmentCreation.java
@@ -1,0 +1,24 @@
+package com.stratio.sparta.testsAT.automated.gui.policies;
+
+import org.testng.annotations.Factory;
+import org.testng.annotations.Test;
+
+import com.stratio.cucumber.testng.CucumberRunner;
+import com.stratio.data.BrowsersDataProvider;
+import com.stratio.sparta.testsAT.utils.BaseTest;
+
+import cucumber.api.CucumberOptions;
+
+@CucumberOptions(features = { "src/test/resources/features/automated/gui/policies/addAutoFragmentCreation.feature" })
+public class AddAutoFragmentCreation extends BaseTest {
+
+    @Factory(enabled = false, dataProviderClass = BrowsersDataProvider.class, dataProvider = "availableUniqueBrowsers")
+    public AddAutoFragmentCreation(String browser) {
+        this.browser = browser;
+    }
+
+    @Test(enabled = true, groups = {"web"})
+    public void checkElementsTest() throws Exception {
+        new CucumberRunner(this.getClass()).runCukes();
+    }
+}

--- a/testsAT/src/test/resources/features/automated/api/policyContexts/getPolicyContexts.feature
+++ b/testsAT/src/test/resources/features/automated/api/policyContexts/getPolicyContexts.feature
@@ -10,10 +10,11 @@ Feature: Test all Get operations for policyContexts in Sparta Swagger API
 	
 	Scenario: Get all policyContexts when one available
 		Given I send a 'POST' request to '/policyContext' based on 'schemas/policies/policy.conf' as 'json' with:
-		| name | UPDATE | policy1 |
+		| name | UPDATE | policyContextAvailable |
 		| fragments | DELETE | N/A |
+		| outputs[1] | DELETE | N/A |
 		| id | DELETE | N/A |
-		Then the service response status must be '200' and its response must contain the text '"policyName":"policy1"'
+		Then the service response status must be '200' and its response must contain the text '"policyName":"policyContextAvailable"'
 		And I save element '$.policyId' in attribute 'previousPolicyID'
 		When I send a 'GET' request to '/policyContext'
 		Then the service response status must be '200' and its response must contain the text '"id":"!{previousPolicyID}"'
@@ -21,4 +22,14 @@ Feature: Test all Get operations for policyContexts in Sparta Swagger API
 	Scenario: Clean up
 		When I send a 'DELETE' request to '/policy/!{previousPolicyID}'
 		Then the service response status must be '200'.
-		
+	 	# Delete fragments
+	 	When I send a 'GET' request to '/fragment/input/name/name'
+	  	Then the service response status must be '200'.
+	  	And I save element '$.id' in attribute 'previousFragmentID'
+	  	When I send a 'DELETE' request to '/fragment/input/!{previousFragmentID}'
+	  	Then the service response status must be '200'.
+	  	When I send a 'GET' request to '/fragment/output/name/name'
+	  	Then the service response status must be '200'.
+	  	And I save element '$.id' in attribute 'previousFragmentID_2'
+	  	When I send a 'DELETE' request to '/fragment/output/!{previousFragmentID_2}'
+	  	Then the service response status must be '200'.

--- a/testsAT/src/test/resources/features/automated/api/policyContexts/postPolicyContexts.feature
+++ b/testsAT/src/test/resources/features/automated/api/policyContexts/postPolicyContexts.feature
@@ -105,7 +105,7 @@ Feature: Test all POST operations for policyContexts in Sparta Swagger API
 		| name | UPDATE | policyContextValid |
 		| fragments | DELETE | N/A |
 		| id | DELETE | N/A |
-		Then the service response status must be '500' and its response must contain the text 'policyContextValid already exists'
+		Then the service response status must be '404' and its response must contain the text 'Can't create policy'
 	
 	Scenario: Add a policyContext with existing fragment
 		When I send a 'POST' request to '/policyContext' based on 'schemas/policies/policy.conf' as 'json' with:
@@ -178,3 +178,30 @@ Feature: Test all POST operations for policyContexts in Sparta Swagger API
 		# Delete policy created with first policyContext
 		When I send a 'DELETE' request to '/policy/!{previousPolicyID}'
 		Then the service response status must be '200'.
+
+		# Delete fragments
+	  	When I send a 'GET' request to '/fragment/input/name/name'
+	  	Then the service response status must be '200'.
+	  	And I save element '$.id' in attribute 'previousFragmentID'
+	  	When I send a 'DELETE' request to '/fragment/input/!{previousFragmentID}'
+	  	Then the service response status must be '200'.
+	  	When I send a 'GET' request to '/fragment/input/name/elementname'
+	  	Then the service response status must be '200'.
+	  	And I save element '$.id' in attribute 'previousFragmentID'
+	  	When I send a 'DELETE' request to '/fragment/input/!{previousFragmentID}'
+	  	Then the service response status must be '200'.
+	  	When I send a 'GET' request to '/fragment/output/name/name'
+	  	Then the service response status must be '200'.
+	  	And I save element '$.id' in attribute 'previousFragmentID_2'
+	  	When I send a 'DELETE' request to '/fragment/output/!{previousFragmentID_2}'
+	  	Then the service response status must be '200'.
+	  	When I send a 'GET' request to '/fragment/output/name/name2'
+	  	Then the service response status must be '200'.
+	  	And I save element '$.id' in attribute 'previousFragmentID_2'
+	  	When I send a 'DELETE' request to '/fragment/output/!{previousFragmentID_2}'
+	  	Then the service response status must be '200'.
+	  	When I send a 'GET' request to '/fragment/output/name/elementname'
+	  	Then the service response status must be '200'.
+	  	And I save element '$.id' in attribute 'previousFragmentID_2'
+	  	When I send a 'DELETE' request to '/fragment/output/!{previousFragmentID_2}'
+	  	Then the service response status must be '200'.

--- a/testsAT/src/test/resources/features/automated/api/policyContexts/putPolicyContexts.feature
+++ b/testsAT/src/test/resources/features/automated/api/policyContexts/putPolicyContexts.feature
@@ -43,3 +43,19 @@ Feature: Test all PUT operations for policyContexts in Sparta Swagger API
 	Scenario: Clean up
 		When I send a 'DELETE' request to '/policy/!{previousPolicyID}'
 		Then the service response status must be '200'.
+	   	# Delete fragments
+	  	When I send a 'GET' request to '/fragment/input/name/name'
+	  	Then the service response status must be '200'.
+	  	And I save element '$.id' in attribute 'previousFragmentID'
+	  	When I send a 'DELETE' request to '/fragment/input/!{previousFragmentID}'
+	  	Then the service response status must be '200'.
+	  	When I send a 'GET' request to '/fragment/output/name/name'
+	  	Then the service response status must be '200'.
+	  	And I save element '$.id' in attribute 'previousFragmentID_2'
+	  	When I send a 'DELETE' request to '/fragment/output/!{previousFragmentID_2}'
+	  	Then the service response status must be '200'.
+	  	When I send a 'GET' request to '/fragment/output/name/name2'
+	  	Then the service response status must be '200'.
+	  	And I save element '$.id' in attribute 'previousFragmentID_2'
+	  	When I send a 'DELETE' request to '/fragment/output/!{previousFragmentID_2}'
+	  	Then the service response status must be '200'.

--- a/testsAT/src/test/resources/features/automated/gui/policies/addAutoFragmentCreation.feature
+++ b/testsAT/src/test/resources/features/automated/gui/policies/addAutoFragmentCreation.feature
@@ -1,0 +1,98 @@
+@web @rest
+Feature: Test adding a new policy in Sparta GUI
+
+  Background: Setup Sparta GUI
+    Given I set web base url to '${SPARTA_HOST}:${SPARTA_PORT}'
+    Given I send requests to '${SPARTA_HOST}:${SPARTA_API_PORT}'
+
+  Scenario: Add a new policy through api
+    When I send a 'POST' request to '/policyContext' based on 'schemas/policies/policy.conf' as 'json' with:
+		| name | UPDATE | policy1 |
+		| fragments | DELETE | N/A |
+		| outputs[1] | DELETE | N/A |
+		| id | DELETE | N/A |
+	Then the service response status must be '200'.
+	And I save element '$.policyId' in attribute 'previousPolicyID'
+	# Check that is listed
+	When I send a 'GET' request to '/policy/all'
+	Then the service response status must be '200' and its response length must be '1'
+    # Check that input has been created
+    When I send a 'GET' request to '/fragment/input'
+	Then the service response status must be '200' and its response length must be '1'
+    # Check that output has been created
+    When I send a 'GET' request to '/fragment/output'
+	Then the service response status must be '200' and its response length must be '1'
+
+    # Browse to policies
+    Given I browse to '/#/dashboard/policies'
+    Then I wait '2' seconds
+    And '1' element exists with 'css:i[data-qa^="policy-context-menu-"]'
+
+    # Browse to inputs
+    Given I browse to '/#/dashboard/inputs'
+    Then I wait '2' seconds
+    And '1' element exists with 'css:span[data-qa^="input-context-menu-"]'
+    # Try to edit input
+    Then I click on the element on index '0'
+	And I wait '1' second
+	Given '1' element exists with 'css:st-menu-element[data-qa$="-edit"]'
+	When I click on the element on index '0'
+	Then I wait '1' second
+	And '1' element exists with 'css:aside[data-qa="fragment-details-modal"]'
+    # Modify
+	Given '1' element exists with 'css:button[data-qa="modal-ok-button"]'
+	When I click on the element on index '0'
+
+    # Browse to outputs
+    Given I browse to '/#/dashboard/outputs'
+    Then I wait '2' seconds
+    And '1' element exists with 'css:span[data-qa^="output-context-menu-"]'
+	# Try to edit output
+	Then I click on the element on index '0'
+	And I wait '1' second
+	Given '1' element exists with 'css:st-menu-element[data-qa$="-edit"]'
+	When I click on the element on index '0'
+	Then I wait '1' second
+	And '1' element exists with 'css:aside[data-qa="fragment-details-modal"]'
+	# Modify
+	Given '1' element exists with 'css:button[data-qa="modal-ok-button"]'
+	When I click on the element on index '0'
+
+	# Add same policy with different name, fragments should be reused
+	 When I send a 'POST' request to '/policyContext' based on 'schemas/policies/policy.conf' as 'json' with:
+		| name | UPDATE | policy2 |
+		| fragments | DELETE | N/A |
+		| outputs[1] | DELETE | N/A |
+		| id | DELETE | N/A |
+	 Then the service response status must be '200'.
+	 And I save element '$.policyId' in attribute 'previousPolicyID_2'
+
+	# Browse to inputs
+    Given I browse to '/#/dashboard/inputs'
+    Then I wait '2' seconds
+    And '1' element exists with 'css:span[data-qa^="input-context-menu-"]'
+
+	# Browse to outputs
+    Given I browse to '/#/dashboard/outputs'
+    Then I wait '2' seconds
+    And '1' element exists with 'css:span[data-qa^="output-context-menu-"]'
+
+    # Delete policy
+    When I send a 'DELETE' request to '/policy/!{previousPolicyID}'
+	Then the service response status must be '200'.
+	When I send a 'DELETE' request to '/policy/!{previousPolicyID_2}'
+	Then the service response status must be '200'.
+	When I send a 'GET' request to '/policy/all'
+	Then the service response status must be '200' and its response must contain the text '[]'
+
+	# Delete fragments
+  	When I send a 'GET' request to '/fragment/input/name/name'
+	Then the service response status must be '200'.
+	And I save element '$.id' in attribute 'previousFragmentID'
+	When I send a 'DELETE' request to '/fragment/input/!{previousFragmentID}'
+	Then the service response status must be '200'.
+	When I send a 'GET' request to '/fragment/output/name/name'
+	Then the service response status must be '200'.
+	And I save element '$.id' in attribute 'previousFragmentID_2'
+	When I send a 'DELETE' request to '/fragment/output/!{previousFragmentID_2}'
+	Then the service response status must be '200'.


### PR DESCRIPTION
The idea is to extract input and outputs out of the policy and parse them into fragments so the policy, inputs and outputs could be shown in the user interface.

**Given** an user using Sparkta with the command line
**When** posts a policy thought policyContext endpoint with a standard policy (see attached file)
**Then** input, outputs and policy should be shown in the user interface

**Given** an user using Sparkta with the command line
**When** posts a new policy using policyContext endpoint with a standard policy which contains existing input/outputs (**exactly equals as existing ones: same name, type and property map**)
**Then** existing input/outputs should be shown in the user interface and policy will start. No error will be thrown and already existing input/outputs will be reused.

**Given** an user using Sparkta with the command line
**When** posts a new policy using policyContext endpoint with a standard policy which contains no existing input/outputs (**different name, type or property map**)
**Then** new input/outputs should be shown in the user interface and policy will start. No error will be thrown.

**Given** an user using Sparkta with the command line
**When** posts a new policy using policyContext endpoint with a standard policy which contains existing input/outputs (**same name but different type or property map**)
**Then** error should be thrown trying to create input/outputs with existing name
