### PR TITLE
SPARKTA-393 fix CustomExceptionHandler behaviour

### DIFF
--- a/serving-api/src/main/scala/com/stratio/sparkta/serving/api/actor/ControllerActor.scala
+++ b/serving-api/src/main/scala/com/stratio/sparkta/serving/api/actor/ControllerActor.scala
@@ -18,37 +18,19 @@ package com.stratio.sparkta.serving.api.actor
 
 import akka.actor.{ActorContext, _}
 import akka.event.slf4j.SLF4JLogging
+import org.apache.curator.framework.CuratorFramework
+import spray.routing._
+
+import com.stratio.sparkta.serving.api.service.handler.CustomExceptionHandler._
 import com.stratio.sparkta.serving.api.service.http._
 import com.stratio.sparkta.serving.core.constants.AkkaConstant
-import com.stratio.sparkta.serving.core.exception.ServingCoreException
-import com.stratio.sparkta.serving.core.models.{ErrorModel, SparktaSerializer}
-import org.apache.curator.framework.CuratorFramework
-import org.json4s.jackson.Serialization.write
-import spray.http.StatusCodes
-import spray.routing._
-import spray.util.LoggingContext
+import com.stratio.sparkta.serving.core.models.SparktaSerializer
 
-class ControllerActor(actorsMap: Map[String, ActorRef], curatorFramework : CuratorFramework) extends HttpServiceActor
-with SLF4JLogging
-with SparktaSerializer {
+class ControllerActor(actorsMap: Map[String, ActorRef], curatorFramework: CuratorFramework) extends HttpServiceActor
+  with SLF4JLogging
+  with SparktaSerializer {
 
   override implicit def actorRefFactory: ActorContext = context
-
-  implicit def exceptionHandler(implicit logg: LoggingContext): ExceptionHandler =
-    ExceptionHandler {
-      case exception: ServingCoreException =>
-        requestUri { uri =>
-          log.error(exception.getLocalizedMessage)
-          complete(StatusCodes.NotFound, write(ErrorModel.toErrorModel(exception.getLocalizedMessage)))
-        }
-      case exception: Throwable =>
-        requestUri { uri =>
-          log.error(exception.getLocalizedMessage, exception)
-          complete(StatusCodes.InternalServerError, write(
-            new ErrorModel(ErrorModel.CodeUnknown, exception.getLocalizedMessage)
-          ))
-        }
-    }
 
   val serviceRoutes: ServiceRoutes = new ServiceRoutes(actorsMap, context, curatorFramework)
 
@@ -73,7 +55,7 @@ with SparktaSerializer {
     }
 }
 
-class ServiceRoutes(actorsMap: Map[String, ActorRef], context: ActorContext, curatorFramework : CuratorFramework) {
+class ServiceRoutes(actorsMap: Map[String, ActorRef], context: ActorContext, curatorFramework: CuratorFramework) {
 
   val fragmentRoute: Route = new FragmentHttpService {
     implicit val actors = actorsMap

--- a/serving-api/src/main/scala/com/stratio/sparkta/serving/api/actor/PolicyActor.scala
+++ b/serving-api/src/main/scala/com/stratio/sparkta/serving/api/actor/PolicyActor.scala
@@ -23,8 +23,7 @@ import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
 
-import akka.actor.Actor
-import akka.actor.ActorRef
+import akka.actor.{Actor, ActorRef}
 import akka.event.slf4j.SLF4JLogging
 import com.typesafe.config.ConfigFactory
 import org.apache.commons.io.FileUtils

--- a/serving-api/src/main/scala/com/stratio/sparkta/serving/api/actor/SwaggerActor.scala
+++ b/serving-api/src/main/scala/com/stratio/sparkta/serving/api/actor/SwaggerActor.scala
@@ -16,44 +16,25 @@
 
 package com.stratio.sparkta.serving.api.actor
 
-import org.apache.curator.framework.CuratorFramework
-
 import scala.reflect.runtime.universe._
 
 import akka.actor.{ActorContext, ActorRef}
 import akka.event.slf4j.SLF4JLogging
 import com.gettyimages.spray.swagger.SwaggerHttpService
-import com.stratio.sparkta.serving.core.exception.ServingCoreException
 import com.wordnik.swagger.model.ApiInfo
-import org.json4s.jackson.Serialization.write
-import spray.http.StatusCodes
+import org.apache.curator.framework.CuratorFramework
 import spray.routing._
-import spray.util.LoggingContext
 
 import com.stratio.sparkta.serving.api.constants.HttpConstant
+import com.stratio.sparkta.serving.api.service.handler.CustomExceptionHandler._
 import com.stratio.sparkta.serving.api.service.http._
-import com.stratio.sparkta.serving.core.models.{ErrorModel, SparktaSerializer}
+import com.stratio.sparkta.serving.core.models.SparktaSerializer
 
-class SwaggerActor(actorsMap: Map[String, ActorRef], curatorFramework : CuratorFramework)
-  extends HttpServiceActor with SLF4JLogging with SparktaSerializer {
+class SwaggerActor(actorsMap: Map[String, ActorRef], curatorFramework: CuratorFramework) extends HttpServiceActor
+  with SLF4JLogging
+  with SparktaSerializer {
 
   override implicit def actorRefFactory: ActorContext = context
-
-  implicit def exceptionHandler(implicit logg: LoggingContext): ExceptionHandler =
-    ExceptionHandler {
-      case exception: ServingCoreException =>
-        requestUri { uri =>
-          log.error(exception.getLocalizedMessage)
-          complete(StatusCodes.NotFound, write(ErrorModel.toErrorModel(exception.getLocalizedMessage)))
-        }
-      case exception: Throwable =>
-        requestUri { uri =>
-          log.error(exception.getLocalizedMessage, exception)
-          complete(StatusCodes.InternalServerError, write(
-            new ErrorModel(ErrorModel.CodeUnknown, exception.getLocalizedMessage)
-          ))
-        }
-    }
 
   val serviceRoutes = new ServiceRoutes(actorsMap, context, curatorFramework)
 

--- a/serving-api/src/main/scala/com/stratio/sparkta/serving/api/actor/TemplateActor.scala
+++ b/serving-api/src/main/scala/com/stratio/sparkta/serving/api/actor/TemplateActor.scala
@@ -29,7 +29,10 @@ import spray.httpx.Json4sJacksonSupport
 
 import scala.util.Try
 
-class TemplateActor extends Actor with Json4sJacksonSupport with SLF4JLogging with SparktaSerializer {
+class TemplateActor extends Actor
+  with Json4sJacksonSupport
+  with SLF4JLogging
+  with SparktaSerializer {
 
   override def receive: Receive = {
 
@@ -44,7 +47,7 @@ class TemplateActor extends Actor with Json4sJacksonSupport with SLF4JLogging wi
         .map(file => {
           log.info(s"> Retrieving template: ${file.getName}")
           read[TemplateModel](getInputStreamFromResource(s"templates/${t}/${file.getName}"))
-      })
+        })
     }).recover {
       case e: NullPointerException => Seq()
     })
@@ -67,7 +70,6 @@ class TemplateActor extends Actor with Json4sJacksonSupport with SLF4JLogging wi
 
   protected def getFilesFromURI(uri: URI): Seq[File] =
     new File(uri).listFiles
-
 }
 
 object TemplateActor {
@@ -79,4 +81,5 @@ object TemplateActor {
   case class ResponseTemplates(templates: Try[Seq[TemplateModel]])
 
   case class ResponseTemplate(template: Try[TemplateModel])
+
 }


### PR DESCRIPTION
Removed implicit handler from some classes in order to use expected CustomExceptionHandler.