### PR TITLE
[SPARTA-410] delete policy context when deleting policy

### DIFF
--- a/serving-core/pom.xml
+++ b/serving-core/pom.xml
@@ -103,6 +103,28 @@
         </dependency>
         <dependency>
             <groupId>io.spray</groupId>
+            <artifactId>spray-testkit_${scala.binary.version}</artifactId>
+            <version>${spray.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.specs2</groupId>
+                    <artifactId>specs2_${scala.binary.version}</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.typesafe.akka</groupId>
+                    <artifactId>akka-testkit_${scala.binary.version}</artifactId>
+                </exclusion>
+            </exclusions>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.spark-project.akka</groupId>
+            <artifactId>akka-testkit_${scala.binary.version}</artifactId>
+            <version>${akka.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.spray</groupId>
             <artifactId>spray-can_${scala.binary.version}</artifactId>
             <version>${spray.version}</version>
         </dependency>

--- a/serving-core/src/test/scala/com/stratio/sparkta/serving/core/policy/status/PolicyStatusActorTest.scala
+++ b/serving-core/src/test/scala/com/stratio/sparkta/serving/core/policy/status/PolicyStatusActorTest.scala
@@ -1,0 +1,117 @@
+/**
+ * Copyright (C) 2016 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.stratio.sparkta.serving.core.policy.status
+
+import scala.util.{Failure, Success}
+
+import akka.actor.{ActorSystem, Props}
+import akka.testkit._
+import akka.util.Timeout
+import org.apache.curator.framework.CuratorFramework
+import org.apache.curator.framework.api._
+import org.apache.zookeeper.data.Stat
+import org.junit.runner.RunWith
+import org.mockito.Mockito._
+import org.scalatest._
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.mock.MockitoSugar
+import scala.concurrent.duration._
+
+import com.stratio.sparkta.serving.core.constants.AppConstant
+import com.stratio.sparkta.serving.core.exception.ServingCoreException
+import com.stratio.sparkta.serving.core.policy.status.PolicyStatusActor.ResponseDelete
+
+@RunWith(classOf[JUnitRunner])
+class PolicyStatusActorTest extends TestKit(ActorSystem("FragmentActorSpec"))
+  with WordSpecLike
+  with Matchers
+  with ImplicitSender
+  with MockitoSugar {
+
+  val curatorFramework = mock[CuratorFramework]
+  val getChildrenBuilder = mock[GetChildrenBuilder]
+  val getDataBuilder = mock[GetDataBuilder]
+  val existsBuilder = mock[ExistsBuilder]
+  val createBuilder = mock[CreateBuilder]
+  val deleteBuilder = mock[DeleteBuilder]
+
+  val actor = system.actorOf(Props(new PolicyStatusActor(curatorFramework)))
+  implicit val timeout: Timeout = Timeout(15.seconds)
+  val id = "existingID"
+
+  "PolicyStatusActor" must {
+
+    "delete: returns success when deleting an existing ID " in {
+      when(curatorFramework
+        .checkExists())
+        .thenReturn(existsBuilder)
+      when(curatorFramework.checkExists()
+        .forPath(s"${AppConstant.ContextPath}/$id"))
+        .thenReturn(new Stat)
+      // scalastyle:off null
+
+      when(curatorFramework.delete())
+        .thenReturn(deleteBuilder)
+      when(curatorFramework.delete()
+        .forPath(s"${AppConstant.ContextPath}/$id"))
+        .thenReturn(null)
+
+      actor ! PolicyStatusActor.Delete(id)
+
+      expectMsg(ResponseDelete(Success(null)))
+      // scalastyle:on null
+
+    }
+
+    "delete: returns failure when deleting an unexisting ID " in {
+      // scalastyle:off null
+      when(curatorFramework
+        .checkExists())
+        .thenReturn(existsBuilder)
+      when(curatorFramework.checkExists()
+        .forPath(s"${AppConstant.ContextPath}/$id"))
+        .thenReturn(null)
+
+     actor ! PolicyStatusActor.Delete(id)
+
+      expectMsgAnyClassOf(classOf[ResponseDelete])
+      // scalastyle:on null
+
+    }
+
+    "delete: returns failure when deleting an existing ID and an error occurs while deleling" in {
+      // scalastyle:off null
+      when(curatorFramework
+        .checkExists())
+        .thenReturn(existsBuilder)
+      when(curatorFramework.checkExists()
+        .forPath(s"${AppConstant.ContextPath}/$id"))
+        .thenReturn(new Stat())
+
+      when(curatorFramework.delete())
+        .thenReturn(deleteBuilder)
+      when(curatorFramework.delete()
+        .forPath(s"${AppConstant.ContextPath}/$id"))
+        .thenThrow(new RuntimeException())
+      actor ! PolicyStatusActor.Delete(id)
+
+      expectMsgAnyClassOf(classOf[ResponseDelete])
+      // scalastyle:on null
+
+    }
+  }
+}

--- a/testsAT/src/test/resources/features/automated/api/policies/deletePolicies.feature
+++ b/testsAT/src/test/resources/features/automated/api/policies/deletePolicies.feature
@@ -6,7 +6,7 @@ Feature: Test all DELETE operations for policies in Sparta Swagger API
 		
 	Scenario: Delete a policy when no policies available
 		When I send a 'DELETE' request to '/policy/nonExistingId'
-		Then the service response status must be '404'.
+		Then the service response status must be '500'.
 	
 	Scenario: Delete a non-existing policy when policies available
 		When I send a 'POST' request to '/policy' based on 'schemas/policies/policy.conf' as 'json' with:
@@ -19,7 +19,7 @@ Feature: Test all DELETE operations for policies in Sparta Swagger API
 		When I send a 'GET' request to '/policy/all'	
 		Then the service response status must be '200' and its response length must be '1'
 		When I send a 'DELETE' request to '/policy/nonExistingId'
-		Then the service response status must be '404'.
+		Then the service response status must be '500'.
 		
 	Scenario: Delete a existing policy
 		When I send a 'DELETE' request to '/policy/!{previousPolicyID}'

--- a/testsAT/src/test/resources/features/automated/gui/policies/deletePolicy.feature
+++ b/testsAT/src/test/resources/features/automated/gui/policies/deletePolicy.feature
@@ -64,6 +64,10 @@ Feature: Test deleting a policy in Sparta GUI
 		Then '1' element exists with 'css:div[data-qa="manage-policies-success-msg"]'
 		And a text 'The policy has been deleted!' exists
 		And '0' elements exist with 'css:i[data-qa^="policy-context-menu-"]'
+		# Check that policyContext has disappeared
+		When I send a 'GET' request to '/policyContext'
+		Then the service response status must be '200'.
+		And the service response must NOT contain the text '!{previousPolicyID}'
 
 		
 		Scenario: Delete fragments


### PR DESCRIPTION
Delete policy context when deleting an existing policy


**Given** an existing policy
**when** trying to delete this policy
**then** this policy and its context must be deleted

**Given** an unexisting policy
**when** trying to delete this policy
**then** an exception will be thrown and 500 status error will the returned