### PR TITLE
SPARKTA-433 Added new parser for geolocation

### DIFF
--- a/plugins/parser-geo/.gitignore
+++ b/plugins/parser-geo/.gitignore
@@ -1,0 +1,1 @@
+/dependency-reduced-pom.xml

--- a/plugins/parser-geo/pom.xml
+++ b/plugins/parser-geo/pom.xml
@@ -1,0 +1,30 @@
+
+<!--
+
+    Copyright (C) 2014 Stratio (http://stratio.com)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>plugins</artifactId>
+        <groupId>com.stratio.sparkta</groupId>
+        <version>0.9.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>parser-geo</artifactId>
+</project>

--- a/plugins/parser-geo/src/main/scala/com/stratio/sparkta/plugin/parser/geo/GeoParser.scala
+++ b/plugins/parser-geo/src/main/scala/com/stratio/sparkta/plugin/parser/geo/GeoParser.scala
@@ -1,0 +1,67 @@
+/**
+ * Copyright (C) 2016 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.stratio.sparkta.plugin.parser.geo
+
+import java.io.{Serializable => JSerializable}
+import com.stratio.sparkta.sdk.Parser
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types.StructType
+
+import scala.util.Try
+
+class GeoParser(
+  name: String,
+  order: Integer,
+  inputField: String,
+  outputFields: Seq[String],
+  schema: StructType,
+  properties: Map[String, JSerializable]
+) extends Parser(name, order, inputField, outputFields, schema, properties) {
+
+  val defaultLatitudeField = "latitude"
+  val defaultLongitudeField = "longitude"
+  val separator = "__"
+
+  val latitudeField = properties.getOrElse("latitude", defaultLatitudeField).toString
+  val longitudeField = properties.getOrElse("longitude", defaultLongitudeField).toString
+
+  def parse(data: Row, removeRaw: Boolean): Row = {
+    val prevData = if (removeRaw) data.toSeq.drop(1) else data.toSeq
+
+    addGeoField(data) match {
+      case Some(geoField) => Row.fromSeq(prevData ++ Seq(geoField))
+      case None => Row.fromSeq(prevData)
+    }
+  }
+
+  private def getLatitude(row: Row): Option[String] =
+    Try(row.get(schema.fieldIndex(latitudeField)))
+      .toOption
+      .map(_.toString)
+
+  private def getLongitude(row: Row): Option[String] =
+    Try(row.get(schema.fieldIndex(longitudeField)))
+      .toOption
+      .map(_.toString)
+
+  private def addGeoField(row: Row): Option[String] =
+    for {
+      lat   <- getLatitude(row)
+      long  <- getLongitude(row)
+    } yield lat + separator + long
+
+}

--- a/plugins/parser-geo/src/test/resources/log4j.xml
+++ b/plugins/parser-geo/src/test/resources/log4j.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+
+    Copyright (C) 2014 Stratio (http://stratio.com)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+            http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+    <appender name="console" class="org.apache.log4j.ConsoleAppender">
+        <param name="Target" value="System.out"/>
+        <layout class="org.apache.log4j.PatternLayout">
+            <param name="ConversionPattern" value="%-5p %c{1} - %m%n"/>
+        </layout>
+    </appender>
+
+    <root>
+        <priority value="debug"/>
+        <appender-ref ref="console"/>
+    </root>
+
+</log4j:configuration>

--- a/plugins/parser-geo/src/test/scala/com/stratio/sparkta/plugin/test/parser/geo/GeoParserTest.scala
+++ b/plugins/parser-geo/src/test/scala/com/stratio/sparkta/plugin/test/parser/geo/GeoParserTest.scala
@@ -1,0 +1,147 @@
+/**
+ * Copyright (C) 2016 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+*/
+
+package com.stratio.sparkta.plugin.test.parser.geo
+
+import java.io.{Serializable => JSerializable}
+
+import com.stratio.sparkta.plugin.parser.geo.GeoParser
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.types._
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.{Matchers, WordSpecLike}
+
+@RunWith(classOf[JUnitRunner])
+class GeoParserTest extends WordSpecLike with Matchers {
+
+  trait GeoParserUnitTestComponent {
+
+    val latitudeField = "lat"
+    val longitudeField = "long"
+    val latitudeValue = "12.1231"
+    val longitudeValue = "13.1231"
+    val outputField = "geo"
+
+    val preRow: Row
+    val postRow: Row
+    val schema: StructType
+    val properties: Map[String, JSerializable]
+
+    lazy val resultantRow: Row = new GeoParser("name", 1, "", Seq(outputField), schema, properties)
+      .parse(preRow, false)
+  }
+
+  "A GeoParser" when {
+    "getLatitude" should {
+      "return the latitude field if it's defined in the properties map" in new GeoParserUnitTestComponent {
+
+        val data = Seq(latitudeValue, longitudeValue)
+        val schema = StructType(Seq(StructField(latitudeField, DoubleType), StructField("longitude", DoubleType)))
+        val properties: Map[String, JSerializable] = Map("latitude" -> latitudeField)
+
+        val preRow = Row.fromSeq(data)
+        val postRow = Row.fromSeq(data ++ Seq(s"${latitudeValue}__$longitudeValue"))
+
+        postRow should be(resultantRow)
+      }
+
+      "return the longitude field if it's defined in the properties map" in new GeoParserUnitTestComponent {
+
+        val data = Seq(latitudeValue, longitudeValue)
+        val schema = StructType(Seq(StructField("latitude", DoubleType), StructField(longitudeField, DoubleType)))
+        val properties = Map("longitude" -> longitudeField)
+
+        val preRow = Row.fromSeq(data)
+        val postRow = Row.fromSeq(data ++ Seq(s"${latitudeValue}__$longitudeValue"))
+
+        postRow should be(resultantRow)
+      }
+
+      "return the default latitude field if it's not defined in the properties map" in new GeoParserUnitTestComponent {
+
+        val data = Seq(latitudeValue, longitudeValue)
+        val schema = StructType(Seq(StructField("latitude", DoubleType), StructField("longitude", DoubleType)))
+        val properties = Map.empty[String, Serializable]
+
+        val preRow = Row.fromSeq(data)
+        val postRow = Row.fromSeq(data ++ Seq(s"${latitudeValue}__$longitudeValue"))
+
+        postRow should be(resultantRow)
+      }
+
+      "return the default longitude field if it's not defined in the properties map" in new GeoParserUnitTestComponent {
+
+        val data = Seq(latitudeValue, longitudeValue)
+        val schema = StructType(Seq(StructField("latitude", DoubleType), StructField("longitude", DoubleType)))
+        val properties = Map.empty[String, Serializable]
+
+        val preRow = Row.fromSeq(data)
+        val postRow = Row.fromSeq(data ++ Seq(s"${latitudeValue}__$longitudeValue"))
+
+        postRow should be(resultantRow)
+      }
+
+      "return the same event if there isn't a latitude field" in new GeoParserUnitTestComponent {
+
+        val data = Seq(longitudeValue)
+        val schema = StructType(Seq(StructField("longitude", DoubleType)))
+        val properties = Map("latitude" -> latitudeField)
+
+        val preRow = Row.fromSeq(data)
+        val postRow = preRow
+
+        postRow should be(resultantRow)
+      }
+
+      "return the same event if there isn't a longitude field" in new GeoParserUnitTestComponent {
+
+        val data = Seq(latitudeValue)
+        val schema = StructType(Seq(StructField("latitude", DoubleType)))
+        val properties = Map("longitude" -> longitudeField)
+
+        val preRow = Row.fromSeq(data)
+        val postRow = preRow
+
+        postRow should be(resultantRow)
+      }
+
+      "return the same event if there isn't a latitude field (default value)" in new GeoParserUnitTestComponent {
+
+        val data = Seq(longitudeValue)
+        val schema = StructType(Seq(StructField("longitude", DoubleType)))
+        val properties = Map.empty[String, Serializable]
+
+        val preRow = Row.fromSeq(data)
+        val postRow = preRow
+
+        postRow should be(resultantRow)
+      }
+
+      "return the same event if there isn't a longitude field (default value)" in new GeoParserUnitTestComponent {
+
+        val data = Seq(latitudeValue)
+        val schema = StructType(Seq(StructField("latitude", DoubleType)))
+        val properties = Map.empty[String, Serializable]
+
+        val preRow = Row.fromSeq(data)
+        val postRow = preRow
+
+        postRow should be(resultantRow)
+      }
+    }
+  }
+}

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -65,6 +65,7 @@
         <module>input-websocket</module>
         <module>parser-datetime</module>
         <module>parser-morphlines</module>
+        <module>parser-geo</module>
         <module>input-rabbitMQ</module>
         <module>parser-ingestion</module>
     </modules>

--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,14 @@
                 <role>developer</role>
             </roles>
         </developer>
+        <developer>
+            <id>dvallejo</id>
+            <name>David Vallejo</name>
+            <email>dvallejo@stratio.com</email>
+            <roles>
+                <role>developer</role>
+            </roles>
+        </developer>
     </developers>
 
     <properties>

--- a/serving-core/src/main/scala/com/stratio/sparkta/serving/core/constants/AppConstant.scala
+++ b/serving-core/src/main/scala/com/stratio/sparkta/serving/core/constants/AppConstant.scala
@@ -134,6 +134,7 @@ object AppConstant {
     s"DateTime${Parser.ClassSuffix}" -> s"parser-datetime$pluginExtension",
     s"Morphlines${Parser.ClassSuffix}" -> s"parser-morphlines$pluginExtension",
     s"Ingestion${Parser.ClassSuffix}" -> s"parser-ingestion$pluginExtension",
-    s"Type${Parser.ClassSuffix}" -> s"parser-type$pluginExtension"
+    s"Type${Parser.ClassSuffix}" -> s"parser-type$pluginExtension",
+    s"Geo${Parser.ClassSuffix}" -> s"parser-geo$pluginExtension"
   )
 }


### PR DESCRIPTION
Added a new parser in order to join latitude and longitude in only one field.

The parser should be something like this:

```javascript
{
      "name": "geo-parser",
      "order": 1,
      "inputField": "",
      "outputFields": [
        "geo"
      ],
      "type": "Geo",
      "configuration": {
        "latitude": "lat",
        "latitude": "long"
      }
    }
```

In the configuration object you can identify the names of the latitude field and longitude field. By default, these names are *latitude* and *longitude*

Ticket in Jira -> [SPARKTA-433](https://stratio.atlassian.net/browse/SPARKTA-433)