### PR TITLE
[SPARKTA-388] fix running policies number on local mode

### DIFF
--- a/serving-api/src/main/scala/com/stratio/sparkta/serving/api/actor/SparkStreamingContextActor.scala
+++ b/serving-api/src/main/scala/com/stratio/sparkta/serving/api/actor/SparkStreamingContextActor.scala
@@ -16,40 +16,27 @@
 
 package com.stratio.sparkta.serving.api.actor
 
-import java.util.UUID
-import scala.collection.JavaConversions
-import scala.concurrent.Await
 import scala.concurrent.ExecutionContext.Implicits._
-import scala.concurrent.duration._
-import scala.util.{Failure, Success, Try}
+import scala.concurrent.Future
+import scala.util.Try
 
 import akka.actor.SupervisorStrategy.Escalate
 import akka.actor._
 import akka.event.slf4j.SLF4JLogging
-import akka.pattern.ask
-import akka.util.Timeout
-import com.typesafe.config.Config
+import akka.pattern.{ask, pipe}
 import org.apache.curator.framework.CuratorFramework
-import org.json4s.jackson.Serialization.{read, write}
 
 import com.stratio.sparkta.driver.service.StreamingContextService
 import com.stratio.sparkta.serving.api.actor.SparkStreamingContextActor._
-import com.stratio.sparkta.serving.api.constants.ActorsConstant
-import com.stratio.sparkta.serving.core.{CuratorFactoryHolder, SparktaConfig}
-import com.stratio.sparkta.serving.core.constants.AppConstant
+import com.stratio.sparkta.serving.api.utils.SparkStreamingContextUtils
 import com.stratio.sparkta.serving.core.exception.ServingCoreException
-import com.stratio.sparkta.serving.core.models.{AggregationPoliciesModel, PolicyStatusModel, SparktaSerializer}
-import com.stratio.sparkta.serving.core.policy.status.PolicyStatusActor.{FindAll, Response, Update}
-import com.stratio.sparkta.serving.core.policy.status.{PolicyStatusActor, PolicyStatusEnum}
+import com.stratio.sparkta.serving.core.models.{AggregationPoliciesModel, SparktaSerializer}
 
 class SparkStreamingContextActor(streamingContextService: StreamingContextService,
                                  policyStatusActor: ActorRef, curatorFramework: CuratorFramework) extends Actor
+  with SparkStreamingContextUtils
   with SLF4JLogging
   with SparktaSerializer {
-
-  val SparkStreamingContextActorPrefix: String = "sparkStreamingContextActor"
-
-  implicit val timeout: Timeout = Timeout(10.seconds)
 
   override val supervisorStrategy =
     OneForOneStrategy() {
@@ -59,146 +46,25 @@ class SparkStreamingContextActor(streamingContextService: StreamingContextServic
     }
 
   override def receive: PartialFunction[Any, Unit] = {
-    case Create(policy) => sender ! create(policy)
+    case Create(policy) => create(policy) pipeTo sender
   }
-
-  def isNotRunning(policy: AggregationPoliciesModel): Boolean = {
-    val future = policyStatusActor ? FindAll
-    val models = Await.result(future, timeout.duration) match {
-      case Response(Success(s)) => s.filter(s => s.id == policy.id.get)
-      case Response(Failure(ex)) => throw ex
-    }
-    models.asInstanceOf[Seq[PolicyStatusModel]].exists(p => p.status match {
-      case PolicyStatusEnum.Launched => false
-      case PolicyStatusEnum.Starting => false
-      case PolicyStatusEnum.Started => false
-      case _ => true
-    })
-  }
-
-  def launch(policy: AggregationPoliciesModel): AggregationPoliciesModel = {
-    if (isNotRunning(policy)) {
-      policyStatusActor ? Update(PolicyStatusModel(policy.id.get, PolicyStatusEnum.Launched))
-      getStreamingContextActor(policy) match {
-        case Some(streamingContextActor) => streamingContextActor ? Start
-        case None =>
-          policyStatusActor ? Update(PolicyStatusModel(policy.id.get, PolicyStatusEnum.Failed))
-      }
-    }
-    else
-      throw new Exception(s"policy ${policy.name} is launched")
-
-    policy
-  }
-
-  def createNewPolicy(policy: AggregationPoliciesModel): AggregationPoliciesModel =
-    existsByName(policy.name) match {
-      case true => log.error(s"${policy.name} already exists. Try deleting first or choosing another name.")
-        throw new RuntimeException(s"${policy.name} already exists")
-      case false => launchNewPolicy(policy)
-    }
 
   /**
    * Tries to create a spark streaming context with a given configuration.
    *
    * @param policy that contains the configuration to run.
    */
-  private def create(policy: AggregationPoliciesModel): Try[AggregationPoliciesModel] =
-    Try(policy.id match {
-      case Some(_) => launch(policy)
-      case None => createNewPolicy(policy)
-    })
-
-  def existsByName(name: String, id: Option[String] = None): Boolean = {
-    val nameToCompare = name.toLowerCase
-    Try({
-      if (CuratorFactoryHolder.existsPath(AppConstant.PoliciesBasePath)) {
-        val children = curatorFramework.getChildren.forPath(s"${AppConstant.PoliciesBasePath}")
-        JavaConversions.asScalaBuffer(children).toList.map(element =>
-          read[AggregationPoliciesModel](new String(curatorFramework.getData.forPath(
-            s"${AppConstant.PoliciesBasePath}/$element"))))
-          .filter(policy => if (id.isDefined) policy.name == nameToCompare && policy.id.get != id.get
-          else policy.name == nameToCompare).toSeq.nonEmpty
-      } else {
-        log.warn(s"Zookeeper path for policies doesn't exists. It will be created.")
-        false
-      }
-    }) match {
-      case Success(result) => result
-      case Failure(exception) => {
-        log.error(exception.getLocalizedMessage, exception)
-        false
-      }
+  def create(policy: AggregationPoliciesModel): Future[Try[AggregationPoliciesModel]] =
+    if (policy.id.isDefined)
+      launch(policy, policyStatusActor, streamingContextService, context)
+    else Future {
+      Try(createNewPolicy(policy, policyStatusActor, curatorFramework, streamingContextService,context))
     }
-  }
-
-  def launchNewPolicy(policy: AggregationPoliciesModel): AggregationPoliciesModel = {
-    val policyWithIdModel = policyWithId(policy)
-
-    for {
-      response <- policyStatusActor ? PolicyStatusActor.Create(PolicyStatusModel(
-        id = policyWithIdModel.id.get,
-        status = PolicyStatusEnum.NotStarted
-      ))
-    } yield policyStatusActor ! Update(PolicyStatusModel(policyWithIdModel.id.get, PolicyStatusEnum.Launched))
-
-    getStreamingContextActor(policyWithIdModel) match {
-      case Some(streamingContextActor) =>
-        // TODO (anistal) change and use PolicyActor.
-        savePolicyInZk(policyWithIdModel)
-        streamingContextActor ? Start
-      case None =>
-        policyStatusActor ? Update(PolicyStatusModel(policyWithIdModel.id.get, PolicyStatusEnum.Failed))
-    }
-    policyWithIdModel
-  }
-
-  private def policyWithId(policy: AggregationPoliciesModel) =
-    (
-      policy.id match {
-        case None => policy.copy(id = Some(UUID.randomUUID.toString))
-        case Some(_) => policy
-      }
-      ).copy(name = policy.name.toLowerCase, version = Some(ActorsConstant.UnitVersion))
-
-  // XXX Private Methods.
-  private def savePolicyInZk(policy: AggregationPoliciesModel): Unit = {
-
-    Try({
-      read[AggregationPoliciesModel](new Predef.String(curatorFramework.getData.forPath(
-        s"${AppConstant.PoliciesBasePath}/${policy.id.get}")))
-    }) match {
-      case Success(_) => log.info(s"Policy ${policy.id.get} already in zookeeper. Updating it...")
-        curatorFramework.setData.forPath(s"${AppConstant.PoliciesBasePath}/${policy.id.get}", write(policy).getBytes)
-      case Failure(e) => curatorFramework.create().creatingParentsIfNeeded().forPath(
-        s"${AppConstant.PoliciesBasePath}/${policy.id.get}", write(policy).getBytes)
-    }
-  }
-
-  private def getStreamingContextActor(policy: AggregationPoliciesModel): Option[ActorRef] = {
-    val actorName = s"$SparkStreamingContextActorPrefix-${policy.name.replace(" ", "_")}"
-    SparktaConfig.getClusterConfig match {
-      case Some(clusterConfig) => {
-
-        log.info(s"launched -> $actorName")
-        Some(context.actorOf(Props(new ClusterLauncherActor(
-          policy, policyStatusActor)), actorName))
-      }
-      case None => {
-        policyStatusActor ! PolicyStatusActor.Kill(actorName)
-        Some(context.actorOf(
-          Props(new LocalSparkStreamingContextActor(
-            policy, streamingContextService, policyStatusActor)), actorName))
-      }
-    }
-  }
 }
 
 object SparkStreamingContextActor {
 
   case class Create(policy: AggregationPoliciesModel)
-
-  case class CreateConfig(config: Config)
 
   case object Start
 

--- a/serving-api/src/main/scala/com/stratio/sparkta/serving/api/helpers/SparktaHelper.scala
+++ b/serving-api/src/main/scala/com/stratio/sparkta/serving/api/helpers/SparktaHelper.scala
@@ -17,12 +17,9 @@
 package com.stratio.sparkta.serving.api.helpers
 
 import scala.collection.JavaConversions
-import scala.util.Failure
-import scala.util.Success
-import scala.util.Try
+import scala.util.{Failure, Success, Try}
 
-import akka.actor.ActorSystem
-import akka.actor.Props
+import akka.actor.{ActorSystem, Props}
 import akka.event.slf4j.SLF4JLogging
 import akka.io.IO
 import akka.routing.RoundRobinPool
@@ -35,14 +32,9 @@ import com.stratio.sparkta.driver.service.StreamingContextService
 import com.stratio.sparkta.serving.api.actor._
 import com.stratio.sparkta.serving.core._
 import com.stratio.sparkta.serving.core.actor.FragmentActor
-import com.stratio.sparkta.serving.core.constants.AkkaConstant
-import com.stratio.sparkta.serving.core.constants.AppConstant
-import com.stratio.sparkta.serving.core.dao.ConfigDAO
-import com.stratio.sparkta.serving.core.dao.ErrorDAO
-import com.stratio.sparkta.serving.core.models.PolicyStatusModel
-import com.stratio.sparkta.serving.core.models.SparktaSerializer
-import com.stratio.sparkta.serving.core.policy.status.PolicyStatusActor
-import com.stratio.sparkta.serving.core.policy.status.PolicyStatusEnum
+import com.stratio.sparkta.serving.core.constants.{AkkaConstant, AppConstant}
+import com.stratio.sparkta.serving.core.models.{PolicyStatusModel, SparktaSerializer}
+import com.stratio.sparkta.serving.core.policy.status.{PolicyStatusActor, PolicyStatusEnum}
 
 /**
  * Helper with common operations used to create a Sparkta context used to run the application.
@@ -139,4 +131,15 @@ object SparktaHelper extends SLF4JLogging
       }
     }
   }
+
+  def getExecutionMode: String = {
+    val detailConfig = SparktaConfig.getDetailConfig.getOrElse(throw new RuntimeException("Error getting Spark config"))
+    detailConfig.getString(AppConstant.ExecutionMode)
+  }
+
+  def isClusterMode: Boolean = {
+    val executionMode = getExecutionMode
+    executionMode == AppConstant.ConfigMesos || executionMode == AppConstant.ConfigYarn
+  }
+
 }

--- a/serving-api/src/main/scala/com/stratio/sparkta/serving/api/service/http/PolicyContextHttpService.scala
+++ b/serving-api/src/main/scala/com/stratio/sparkta/serving/api/service/http/PolicyContextHttpService.scala
@@ -126,7 +126,7 @@ trait PolicyContextHttpService extends BaseHttpService {
                     createFragments(fragmentActor, outputs.toList ::: inputs.toList)
                     PolicyResult(policy.id.getOrElse(""), p.name)
                   case Failure(ex: Throwable) => throw new ServingCoreException(ErrorModel.toString(
-                    ErrorModel(ErrorModel.CodeErrorCreatingPolicy, s"Can't create policy")
+                    ErrorModel(ErrorModel.CodeErrorCreatingPolicy, "Can't create policy")
                   ))
                 }
               }

--- a/serving-api/src/main/scala/com/stratio/sparkta/serving/api/service/http/PolicyHttpService.scala
+++ b/serving-api/src/main/scala/com/stratio/sparkta/serving/api/service/http/PolicyHttpService.scala
@@ -282,7 +282,7 @@ trait PolicyHttpService extends BaseHttpService with SparktaSerializer {
             validate(isValidAndMessageTuple._1, isValidAndMessageTuple._2) {
               complete {
                 val response = actors.get(AkkaConstant.SparkStreamingContextActor).get ?
-                  new SparkStreamingContextActor.Create(parsedP)
+                  SparkStreamingContextActor.Create(parsedP)
                 Await.result(response, timeout.duration) match {
                   case Failure(ex) => throw ex
                   case Success(_) => new Result("Creating new context with name " + policy.name)

--- a/serving-api/src/main/scala/com/stratio/sparkta/serving/api/utils/PolicyStatusUtils.scala
+++ b/serving-api/src/main/scala/com/stratio/sparkta/serving/api/utils/PolicyStatusUtils.scala
@@ -1,0 +1,78 @@
+/**
+ * Copyright (C) 2016 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.stratio.sparkta.serving.api.utils
+
+import scala.concurrent.ExecutionContext.Implicits._
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.util.Success
+
+import akka.actor.ActorRef
+import akka.pattern.ask
+import akka.util.Timeout
+
+import com.stratio.sparkta.serving.api.helpers.SparktaHelper._
+import com.stratio.sparkta.serving.core.models.{AggregationPoliciesModel, PolicyStatusModel}
+import com.stratio.sparkta.serving.core.policy.status.PolicyStatusActor._
+import com.stratio.sparkta.serving.core.policy.status.{PolicyStatusActor, PolicyStatusEnum}
+
+trait PolicyStatusUtils {
+
+  implicit val timeout: Timeout = Timeout(15.seconds)
+
+  def isAnyPolicyStarted(policyStatusActor: ActorRef): Future[Boolean] = {
+    for {
+      response <- findAllPolicies(policyStatusActor)
+    } yield response.policyStatus match {
+      case Success(seq) =>
+        seq.exists(_.status == PolicyStatusEnum.Started) ||
+          seq.exists(_.status == PolicyStatusEnum.Starting)
+      case _ => false
+    }
+  }
+
+  def isContextAvailable(policyStatusActor: ActorRef): Future[Boolean] =
+    for {
+      maybeStarted <- isAnyPolicyStarted(policyStatusActor)
+      clusterMode = isClusterMode
+    } yield (clusterMode, maybeStarted) match {
+      case (true, _) => true
+      case (false, false) => true
+      case (false, true) => throw new RuntimeException(s"One policy is already launched")
+    }
+
+  def findAllPolicies(policyStatusActor: ActorRef): Future[Response] = {
+    (policyStatusActor ? FindAll).mapTo[Response]
+  }
+
+  def updatePolicy(policy: AggregationPoliciesModel, status: PolicyStatusEnum.Value,
+                   policyStatusActor: ActorRef): Unit = {
+    policyStatusActor ! Update(PolicyStatusModel(policy.id.get, status))
+  }
+
+  def createPolicy(policyStatusActor: ActorRef,
+                   policyWithIdModel: AggregationPoliciesModel): Future[Option[PolicyStatusModel]] = {
+    (policyStatusActor ? PolicyStatusActor.Create(PolicyStatusModel(
+      id = policyWithIdModel.id.get,
+      status = PolicyStatusEnum.NotStarted
+    ))).mapTo[Option[PolicyStatusModel]]
+  }
+
+  def killPolicy(policyStatusActor: ActorRef, actorName: String): Unit = {
+    policyStatusActor ! PolicyStatusActor.Kill(actorName)
+  }
+}

--- a/serving-api/src/main/scala/com/stratio/sparkta/serving/api/utils/PolicyUtils.scala
+++ b/serving-api/src/main/scala/com/stratio/sparkta/serving/api/utils/PolicyUtils.scala
@@ -1,0 +1,107 @@
+/**
+ * Copyright (C) 2016 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.stratio.sparkta.serving.api.utils
+
+import java.util.UUID
+import scala.collection.JavaConversions
+import scala.util._
+
+import org.apache.curator.framework.CuratorFramework
+import org.json4s.jackson.Serialization._
+
+import com.stratio.sparkta.serving.api.constants.ActorsConstant
+import com.stratio.sparkta.serving.api.helpers.SparktaHelper._
+import com.stratio.sparkta.serving.core.CuratorFactoryHolder
+import com.stratio.sparkta.serving.core.constants.AppConstant
+import com.stratio.sparkta.serving.core.models.AggregationPoliciesModel
+
+trait PolicyUtils {
+
+  def existsByName(name: String,
+                   id: Option[String] = None,
+                   curatorFramework: CuratorFramework): Boolean = {
+    val nameToCompare = name.toLowerCase
+    Try({
+      if (existsPath) {
+        getPolicies(curatorFramework)
+          .filter(byName(id, nameToCompare)).toSeq.nonEmpty
+      } else {
+        log.warn(s"Zookeeper path for policies doesn't exists. It will be created.")
+        false
+      }
+    }) match {
+      case Success(result) => result
+      case Failure(exception) => {
+        log.error(exception.getLocalizedMessage, exception)
+        false
+      }
+    }
+  }
+
+  def existsPath: Boolean = {
+    CuratorFactoryHolder.existsPath(AppConstant.PoliciesBasePath)
+  }
+
+  def byName(id: Option[String], nameToCompare: String): (AggregationPoliciesModel) => Boolean = {
+    policy =>
+      if (id.isDefined)
+        policy.name == nameToCompare && policy.id.get != id.get
+      else policy.name == nameToCompare
+  }
+
+  def getPolicies(curatorFramework: CuratorFramework): List[AggregationPoliciesModel] = {
+    val children = curatorFramework.getChildren.forPath(s"${AppConstant.PoliciesBasePath}")
+    JavaConversions.asScalaBuffer(children).toList.map(element =>
+      read[AggregationPoliciesModel](new String(curatorFramework.getData.forPath(
+        s"${AppConstant.PoliciesBasePath}/$element"))))
+  }
+
+  def savePolicyInZk(policy: AggregationPoliciesModel, curatorFramework: CuratorFramework): Unit = {
+
+    Try({
+      populatePolicy(policy, curatorFramework)
+    }) match {
+      case Success(_) => log.info(s"Policy ${policy.id.get} already in zookeeper. Updating it...")
+        updatePolicy(policy, curatorFramework)
+      case Failure(e) => writePolicy(policy, curatorFramework)
+    }
+  }
+
+  def writePolicy(policy: AggregationPoliciesModel, curatorFramework: CuratorFramework): Unit = {
+    curatorFramework.create().creatingParentsIfNeeded().forPath(
+      s"${AppConstant.PoliciesBasePath}/${policy.id.get}", write(policy).getBytes)
+  }
+
+  def updatePolicy(policy: AggregationPoliciesModel, curatorFramework: CuratorFramework): Unit = {
+    curatorFramework.setData.forPath(s"${AppConstant.PoliciesBasePath}/${policy.id.get}", write(policy).getBytes)
+  }
+
+  def populatePolicy(policy: AggregationPoliciesModel, curatorFramework: CuratorFramework): AggregationPoliciesModel = {
+    read[AggregationPoliciesModel](new Predef.String(curatorFramework.getData.forPath(
+      s"${AppConstant.PoliciesBasePath}/${policy.id.get}")))
+  }
+
+  def policyWithId(policy: AggregationPoliciesModel): AggregationPoliciesModel =
+    (policy.id match {
+      case None => populatePolicyWithRandomUUID(policy)
+      case Some(_) => policy
+    }).copy(name = policy.name.toLowerCase, version = Some(ActorsConstant.UnitVersion))
+
+  def populatePolicyWithRandomUUID(policy: AggregationPoliciesModel): AggregationPoliciesModel = {
+    policy.copy(id = Some(UUID.randomUUID.toString))
+  }
+}

--- a/serving-api/src/main/scala/com/stratio/sparkta/serving/api/utils/SparkStreamingContextUtils.scala
+++ b/serving-api/src/main/scala/com/stratio/sparkta/serving/api/utils/SparkStreamingContextUtils.scala
@@ -1,0 +1,118 @@
+/**
+ * Copyright (C) 2016 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.stratio.sparkta.serving.api.utils
+
+import scala.concurrent.ExecutionContext.Implicits._
+import scala.concurrent.Future
+import scala.util.Try
+
+import akka.actor._
+import akka.pattern.ask
+import org.apache.curator.framework.CuratorFramework
+
+import com.stratio.sparkta.driver.service.StreamingContextService
+import com.stratio.sparkta.serving.api.actor.SparkStreamingContextActor.Start
+import com.stratio.sparkta.serving.api.actor.{ClusterLauncherActor, LocalSparkStreamingContextActor}
+import com.stratio.sparkta.serving.api.helpers.SparktaHelper._
+import com.stratio.sparkta.serving.core.SparktaConfig
+import com.stratio.sparkta.serving.core.models.AggregationPoliciesModel
+import com.stratio.sparkta.serving.core.policy.status.PolicyStatusEnum
+
+trait SparkStreamingContextUtils extends PolicyStatusUtils
+  with PolicyUtils {
+
+  val SparkStreamingContextActorPrefix: String = "sparkStreamingContextActor"
+
+  def launch(policy: AggregationPoliciesModel,
+             policyStatusActor: ActorRef,
+             streamingContextService: StreamingContextService,
+             context: ActorContext): Future[Try[AggregationPoliciesModel]] =
+    for {
+      isAvailable <- isContextAvailable(policyStatusActor)
+    } yield Try {
+      updatePolicy(policy, PolicyStatusEnum.Launched, policyStatusActor)
+      getStreamingContextActor(policy, policyStatusActor, streamingContextService, context) match {
+        case Some(streamingContextActor) => startPolicy(streamingContextActor)
+        case None => updatePolicy(policy, PolicyStatusEnum.Failed, policyStatusActor)
+      }
+      policy
+    }
+
+  def startPolicy(streamingContextActor: ActorRef): Future[Any] = {
+    streamingContextActor ? Start
+  }
+
+  def createNewPolicy(policy: AggregationPoliciesModel,
+                      policyStatusActor: ActorRef,
+                      curatorFramework: CuratorFramework,
+                      streamingContextService: StreamingContextService,
+                      context: ActorContext): AggregationPoliciesModel =
+    existsByName(policy.name, None, curatorFramework) match {
+      case true =>
+        log.error(s"${policy.name} already exists. Try deleting first or choosing another name.")
+        throw new RuntimeException(s"${policy.name} already exists")
+      case false => launchNewPolicy(policy, policyStatusActor, curatorFramework, streamingContextService, context)
+    }
+
+  def launchNewPolicy(policy: AggregationPoliciesModel,
+                      policyStatusActor: ActorRef,
+                      curatorFramework: CuratorFramework,
+                      streamingContextService: StreamingContextService,
+                      context: ActorContext): AggregationPoliciesModel = {
+    val policyWithIdModel = policyWithId(policy)
+    for {
+      _ <- createPolicy(policyStatusActor, policyWithIdModel)
+    } yield {
+      savePolicyInZk(policyWithIdModel, curatorFramework)
+      launch(policyWithIdModel, policyStatusActor, streamingContextService, context)
+    }
+    policyWithIdModel
+  }
+
+  def getStreamingContextActor(policy: AggregationPoliciesModel,
+                               policyStatusActor: ActorRef,
+                               streamingContextService: StreamingContextService,
+                               context: ActorContext): Option[ActorRef] = {
+    val actorName = s"$SparkStreamingContextActorPrefix-${policy.name.replace(" ", "_")}"
+    SparktaConfig.getClusterConfig match {
+      case Some(clusterConfig) => {
+        log.info(s"launched -> $actorName")
+        getClusterLauncher(policy, policyStatusActor, context, actorName)
+      }
+      case None => {
+        killPolicy(policyStatusActor, actorName)
+        getLocalLauncher(policy, policyStatusActor, streamingContextService, context, actorName)
+      }
+    }
+  }
+
+  def getLocalLauncher(policy: AggregationPoliciesModel,
+                       policyStatusActor: ActorRef,
+                       streamingContextService: StreamingContextService,
+                       context: ActorContext,
+                       actorName: String): Option[ActorRef] = {
+    Some(context.actorOf(Props(new LocalSparkStreamingContextActor(policy, streamingContextService, policyStatusActor)),
+      actorName))
+  }
+
+  def getClusterLauncher(policy: AggregationPoliciesModel,
+                         policyStatusActor: ActorRef,
+                         context: ActorContext,
+                         actorName: String): Option[ActorRef] = {
+    Some(context.actorOf(Props(new ClusterLauncherActor(policy, policyStatusActor)), actorName))
+  }
+}

--- a/serving-api/src/test/scala/com/stratio/sparkta/serving/api/helpers/SparktaHelperTest.scala
+++ b/serving-api/src/test/scala/com/stratio/sparkta/serving/api/helpers/SparktaHelperTest.scala
@@ -1,0 +1,116 @@
+/**
+ * Copyright (C) 2016 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.stratio.sparkta.serving.api.helpers
+
+import com.typesafe.config.{Config, ConfigFactory}
+import org.junit.runner.RunWith
+import org.scalamock.scalatest.MockFactory
+import org.scalatest._
+import org.scalatest.junit.JUnitRunner
+
+import com.stratio.sparkta.serving.core.constants.AppConstant
+import com.stratio.sparkta.serving.core.{MockConfigFactory, SparktaConfig}
+
+@RunWith(classOf[JUnitRunner])
+class SparktaHelperTest extends WordSpec with Matchers with MockFactory {
+
+
+  "SparktaHelper.getExecutionMode" should {
+
+    "return local execution mode" in {
+      val config = ConfigFactory.parseString(
+        """
+          |sparkta{
+          |   config {
+          |     executionMode = local
+          |     rememberPartitioner = true
+          |     stopGracefully = true
+          |   }
+          |}
+        """.stripMargin)
+
+      SparktaConfig.initMainConfig(Some(config), new MockConfigFactory(config))
+      SparktaHelper.getExecutionMode should be(AppConstant.ConfigLocal)
+    }
+
+    "return exception when no valid config exists" in {
+      val config = ConfigFactory.parseString(
+        """
+          |sparkta{
+          |
+          |}
+        """.stripMargin)
+
+      SparktaConfig.initMainConfig(Some(config), new MockConfigFactory(config))
+
+      intercept[RuntimeException]{
+        SparktaHelper.getExecutionMode
+      }
+    }
+  }
+
+  "SparktaHelper.isClusterMode" should {
+
+    "return true when execution mode is local" in {
+      val config = ConfigFactory.parseString(
+        """
+          |sparkta{
+          |   config {
+          |     executionMode = local
+          |     rememberPartitioner = true
+          |     stopGracefully = true
+          |   }
+          |}
+        """.stripMargin)
+      SparktaConfig.initMainConfig(Option(config),new MockConfigFactory(config))
+
+      SparktaHelper.isClusterMode should be (false)
+    }
+
+    "return true when execution mode is standalone" in {
+      val config = ConfigFactory.parseString(
+        """
+          |sparkta{
+          |   config {
+          |     executionMode = standalone
+          |     rememberPartitioner = true
+          |     stopGracefully = true
+          |   }
+          |}
+        """.stripMargin)
+      SparktaConfig.initMainConfig(Option(config),new MockConfigFactory(config))
+
+      SparktaHelper.isClusterMode should be (false)
+    }
+
+    "return false when execution mode is yarn or mesos" in {
+      val config = ConfigFactory.parseString(
+        """
+          |sparkta{
+          |   config {
+          |     executionMode = yarn
+          |     rememberPartitioner = true
+          |     stopGracefully = true
+          |   }
+          |}
+        """.stripMargin)
+      SparktaConfig.initMainConfig(Option(config),new MockConfigFactory(config))
+
+      SparktaHelper.isClusterMode should be (true)
+    }
+  }
+}

--- a/serving-api/src/test/scala/com/stratio/sparkta/serving/api/utils/BaseUtilsTest.scala
+++ b/serving-api/src/test/scala/com/stratio/sparkta/serving/api/utils/BaseUtilsTest.scala
@@ -1,0 +1,160 @@
+/**
+ * Copyright (C) 2016 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.stratio.sparkta.serving.api.utils
+
+import akka.actor.{ActorSystem, Props}
+import akka.testkit._
+import com.typesafe.config.ConfigFactory
+import org.apache.curator.framework.CuratorFramework
+import org.scalatest._
+import org.scalatest.mock.MockitoSugar
+
+import com.stratio.sparkta.driver.service.StreamingContextService
+import com.stratio.sparkta.sdk.{DimensionType, Input}
+import com.stratio.sparkta.serving.api.actor.SparkStreamingContextActor
+import com.stratio.sparkta.serving.core.models._
+import com.stratio.sparkta.serving.core.policy.status.PolicyStatusActor
+
+abstract class BaseUtilsTest extends TestKit(ActorSystem("UtilsText"))
+
+  with WordSpecLike
+  with Matchers
+  with ImplicitSender
+  with MockitoSugar {
+
+  val curatorFramework = mock[CuratorFramework]
+  val streamingContextService = mock[StreamingContextService]
+
+  val policyStatusTestActorRef = TestActorRef(new PolicyStatusActor(curatorFramework))
+  val policyStatusActorRef = system.actorOf(Props(new PolicyStatusActor(curatorFramework)))
+  val policyStatusActor = policyStatusTestActorRef.underlyingActor
+
+  val sparkStreamingContextTestActorRef = TestActorRef(new SparkStreamingContextActor(
+    streamingContextService = streamingContextService,
+    policyStatusActor = policyStatusActorRef,
+    curatorFramework = curatorFramework))
+  val sparkStreamingContextActorRef = system.actorOf(Props(new SparkStreamingContextActor(
+    streamingContextService = streamingContextService,
+    policyStatusActor = policyStatusActorRef,
+    curatorFramework = curatorFramework)))
+
+  val localConfig = ConfigFactory.parseString(
+    """
+      |sparkta{
+      |   config {
+      |     executionMode = local
+      |   }
+      |
+      |   local {
+      |    spark.app.name = SPARKTA
+      |    spark.master = "local[*]"
+      |    spark.executor.memory = 1024m
+      |    spark.app.name = SPARKTA
+      |    spark.sql.parquet.binaryAsString = true
+      |    spark.streaming.concurrentJobs = 1
+      |    #spark.metrics.conf = /opt/sds/sparkta/benchmark/src/main/resources/metrics.properties
+      |  }
+      |}
+    """.stripMargin)
+  val standaloneConfig = ConfigFactory.parseString(
+    """
+      |sparkta{
+      |   config {
+      |     executionMode = standalone
+      |   }
+      |}
+    """.stripMargin)
+
+  val yarnConfig = ConfigFactory.parseString(
+    """
+      |sparkta{
+      |   config {
+      |     executionMode = yarn
+      |   }
+      |}
+    """.stripMargin)
+
+  val mesosConfig = ConfigFactory.parseString(
+    """
+      |sparkta{
+      |   config {
+      |     executionMode = mesos
+      |   }
+      |
+      |   mesos {
+      |    sparkHome = ""
+      |    deployMode = cluster
+      |    numExecutors = 2
+      |    master =  "mesos://127.0.0.1:5050"
+      |    spark.app.name = SPARKTA
+      |    spark.streaming.concurrentJobs = 1
+      |    spark.cores.max = 2
+      |    spark.mesos.extra.cores = 1
+      |    spark.mesos.coarse = true
+      |    spark.executor.memory = 2G
+      |    spark.driver.cores = 1
+      |    spark.driver.memory= 2G
+      |    #spark.metrics.conf = /opt/sds/sparkta/benchmark/src/main/resources/metrics.properties
+      |  }
+      |}
+    """.stripMargin)
+  val interval = 60000
+
+  protected def getPolicyModel(id: String = "testpolicy"): AggregationPoliciesModel = {
+    val rawData = new RawDataModel
+    val outputFieldModel1 = OutputFieldsModel("out1")
+    val outputFieldModel2 = OutputFieldsModel("out2")
+
+    val transformations = Seq(TransformationsModel(
+      name = "transformation1",
+      "Morphlines",
+      0,
+      Input.RawDataKey,
+      Seq(outputFieldModel1, outputFieldModel2),
+      Map()))
+    val checkpointModel = CheckpointModel("minute", "minute", None, interval)
+    val dimensionModel = Seq(DimensionModel(
+      "dimensionName",
+      "field1",
+      DimensionType.IdentityName,
+      DimensionType.DefaultDimensionClass,
+      Some(Map())
+    ))
+    val operators = Seq(OperatorModel("Count", "countoperator", Map()))
+    val cubes = Seq(CubeModel("cube1",
+      checkpointModel,
+      dimensionModel,
+      operators))
+    val outputs = Seq(PolicyElementModel("mongo", "MongoDb", Map()))
+    val input = Some(PolicyElementModel("kafka", "Kafka", Map()))
+    val policy = AggregationPoliciesModel(id = Option("id"),
+      version = None,
+      storageLevel = AggregationPoliciesModel.storageDefaultValue,
+      name = id,
+      description = "whatever",
+      sparkStreamingWindow = AggregationPoliciesModel.sparkStreamingWindow,
+      checkpointPath = "test/test",
+      rawData,
+      transformations,
+      cubes,
+      input,
+      outputs,
+      Seq(),
+      userPluginsJars = Seq.empty[String])
+    policy
+  }
+}

--- a/serving-api/src/test/scala/com/stratio/sparkta/serving/api/utils/PolicyStatusUtilsTest.scala
+++ b/serving-api/src/test/scala/com/stratio/sparkta/serving/api/utils/PolicyStatusUtilsTest.scala
@@ -1,0 +1,152 @@
+/**
+ * Copyright (C) 2016 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.stratio.sparkta.serving.api.utils
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.util.Success
+
+import org.mockito.Mockito._
+
+import com.stratio.sparkta.serving.core.models.PolicyStatusModel
+import com.stratio.sparkta.serving.core.policy.status.PolicyStatusActor.Response
+import com.stratio.sparkta.serving.core.policy.status.PolicyStatusEnum
+import com.stratio.sparkta.serving.core.{MockConfigFactory, SparktaConfig}
+
+class PolicyStatusUtilsTest extends BaseUtilsTest with PolicyStatusUtils {
+
+  "SparkStreamingContextActor.isAnyPolicyStarted" should {
+
+    "return true if any policy is Started" in {
+      val spyActor = spy(this)
+      doReturn(
+        Future(Response(Success(Seq(PolicyStatusModel(id = "id1", status = PolicyStatusEnum.Started))))))
+        .when(spyActor)
+        .findAllPolicies(policyStatusActorRef)
+
+      for {
+        response <- spyActor.isAnyPolicyStarted(policyStatusActorRef)
+      } yield response should be(Future(true))
+    }
+
+
+    "return true if any policy is Starting" in {
+      val spyActor = spy(this)
+      doReturn(
+        Future(Response(Success(Seq(PolicyStatusModel(id = "id1", status = PolicyStatusEnum.Starting))))))
+        .when(spyActor)
+        .findAllPolicies(policyStatusActorRef)
+
+      for {
+        response <- spyActor.isAnyPolicyStarted(policyStatusActorRef)
+      } yield response should be(Future(true))
+    }
+
+    "return false if there is no policy Starting/Started mode" in {
+      val spyActor = spy(this)
+      doReturn(
+        Future(Response(Success(Seq(PolicyStatusModel(id = "id1", status = PolicyStatusEnum.Failed),
+          PolicyStatusModel(id = "id1", status = PolicyStatusEnum.Launched),
+          PolicyStatusModel(id = "id1", status = PolicyStatusEnum.NotStarted),
+          PolicyStatusModel(id = "id1", status = PolicyStatusEnum.Stopped),
+          PolicyStatusModel(id = "id1", status = PolicyStatusEnum.Stopping))))))
+        .when(spyActor)
+        .findAllPolicies(policyStatusActorRef)
+
+
+      for {
+        response <- spyActor.isAnyPolicyStarted(policyStatusActorRef)
+      } yield response should be(Future(false))
+    }
+  }
+
+  "SparkStreamingContextActor.isContextAvailable" should {
+    "return true when execution mode is yarn" in {
+      val spyActor = spy(this)
+      doReturn(
+        Future(Response(Success(Seq(PolicyStatusModel(id = "id1", status = PolicyStatusEnum.Starting))))))
+        .when(spyActor)
+        .findAllPolicies(policyStatusActorRef)
+
+
+      SparktaConfig.initMainConfig(Option(yarnConfig), new MockConfigFactory(yarnConfig))
+
+      for {
+        response <- spyActor.isContextAvailable(policyStatusActorRef)
+      } yield response should be(true)
+    }
+
+    "return true when execution mode is mesos" in {
+      val spyActor = spy(this)
+      doReturn(
+        Future(Response(Success(Seq(PolicyStatusModel(id = "id1", status = PolicyStatusEnum.Started))))))
+        .when(spyActor)
+        .findAllPolicies(policyStatusActorRef)
+
+
+      SparktaConfig.initMainConfig(Option(mesosConfig), new MockConfigFactory(mesosConfig))
+
+      for {
+        response <- spyActor.isContextAvailable(policyStatusActorRef)
+      } yield response should be(true)
+    }
+
+
+    "return true when execution mode is local and there is no running policy" in {
+      val spyActor = spy(this)
+      doReturn(
+        Future(Response(Success(Seq(PolicyStatusModel(id = "id1", status = PolicyStatusEnum.Stopped))))))
+        .when(spyActor)
+        .findAllPolicies(policyStatusActorRef)
+
+
+      SparktaConfig.initMainConfig(Option(localConfig), new MockConfigFactory(localConfig))
+
+      for {
+        response <- spyActor.isContextAvailable(policyStatusActorRef)
+      } yield response should be(true)
+    }
+
+    "return true when execution mode is standalone and there is no running policy" in {
+      val spyActor = spy(this)
+      doReturn(
+        Future(Response(Success(Seq(PolicyStatusModel(id = "id1", status = PolicyStatusEnum.Failed))))))
+        .when(spyActor)
+        .findAllPolicies(policyStatusActorRef)
+
+
+      SparktaConfig.initMainConfig(Option(standaloneConfig), new MockConfigFactory(standaloneConfig))
+
+      for {
+        response <- spyActor.isContextAvailable(policyStatusActorRef)
+      } yield response should be(true)
+    }
+
+    "return false when execution mode is local and there is already one running policy" in {
+      val spyActor = spy(this)
+      doReturn(Future(true))
+        .when(spyActor)
+        .isAnyPolicyStarted(policyStatusActorRef)
+
+      SparktaConfig.initMainConfig(Option(localConfig), new MockConfigFactory(localConfig))
+
+      for {
+        response <- spyActor.isContextAvailable(policyStatusActorRef)
+      } yield response should be(false)
+    }
+  }
+}

--- a/serving-api/src/test/scala/com/stratio/sparkta/serving/api/utils/PolicyUtilsTest.scala
+++ b/serving-api/src/test/scala/com/stratio/sparkta/serving/api/utils/PolicyUtilsTest.scala
@@ -1,0 +1,97 @@
+/**
+ * Copyright (C) 2016 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.stratio.sparkta.serving.api.utils
+
+import org.mockito.Mockito._
+
+class PolicyUtilsTest extends BaseUtilsTest
+  with PolicyUtils {
+
+  val utils = spy(this)
+
+  "PolicyUtils.existsByName" should {
+    "return true if al least exists one policy with the same name" in {
+      doReturn(true)
+        .when(utils)
+        .existsPath
+      doReturn(List(getPolicyModel(id = "policy1"), getPolicyModel(id = "policy2"), getPolicyModel(id = "policy3")))
+        .when(utils)
+        .getPolicies(curatorFramework)
+
+      utils.existsByName(name = "policy1", id = None, curatorFramework = curatorFramework) should be(true)
+    }
+
+    "return false if does not exist any policy with the same name" in {
+      doReturn(true)
+        .when(utils)
+        .existsPath
+      doReturn(List(getPolicyModel(id = "policy1"), getPolicyModel(id = "policy2"), getPolicyModel(id = "policy3")))
+        .when(utils)
+        .getPolicies(curatorFramework)
+
+      utils.existsByName(name = "policy0", id = None, curatorFramework = curatorFramework) should be(false)
+    }
+
+
+    "return false if does not exist the path" in {
+      doReturn(false)
+        .when(utils)
+        .existsPath
+
+      utils.existsByName(name = "policy0", id = None, curatorFramework = curatorFramework) should be(false)
+    }
+
+    "return false if any exception is thrown" in {
+      doReturn(true)
+        .when(utils)
+        .existsPath
+      doThrow(new RuntimeException)
+        .when(utils)
+        .getPolicies(curatorFramework)
+
+      utils.existsByName(name = "policy0", id = None, curatorFramework = curatorFramework) should be(false)
+    }
+  }
+
+  "PolicyUtils.savePolicyInZk" should {
+    "update policy when this exists" in {
+      doReturn(getPolicyModel())
+        .when(utils)
+        .populatePolicy(getPolicyModel(), curatorFramework)
+      doNothing()
+        .when(utils)
+        .updatePolicy(getPolicyModel(), curatorFramework)
+
+      utils.savePolicyInZk(policy = getPolicyModel(), curatorFramework)
+
+      verify(utils).updatePolicy(getPolicyModel(), curatorFramework)
+    }
+
+    "write policy when this does not exist" in {
+      doThrow(new RuntimeException)
+        .when(utils)
+        .populatePolicy(getPolicyModel(), curatorFramework)
+      doNothing()
+        .when(utils)
+        .writePolicy(getPolicyModel(), curatorFramework)
+
+      utils.savePolicyInZk(policy = getPolicyModel(), curatorFramework)
+
+      verify(utils).writePolicy(getPolicyModel(), curatorFramework)
+    }
+  }
+}

--- a/serving-api/src/test/scala/com/stratio/sparkta/serving/api/utils/SparkStreamingContextUtilsTest.scala
+++ b/serving-api/src/test/scala/com/stratio/sparkta/serving/api/utils/SparkStreamingContextUtilsTest.scala
@@ -1,0 +1,192 @@
+/**
+ * Copyright (C) 2016 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.stratio.sparkta.serving.api.utils
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+import scala.util.Success
+
+import akka.actor.ActorRef
+import org.mockito.Matchers
+import org.mockito.Mockito._
+import org.scalatest.BeforeAndAfter
+
+import com.stratio.sparkta.serving.core.models.PolicyStatusModel
+import com.stratio.sparkta.serving.core.policy.status.PolicyStatusEnum
+import com.stratio.sparkta.serving.core.{MockConfigFactory, SparktaConfig}
+
+class SparkStreamingContextUtilsTest extends BaseUtilsTest
+  with SparkStreamingContextUtils
+  with BeforeAndAfter {
+
+  val policyModel = getPolicyModel()
+  val spyActor = spy(this)
+  val policyStatusModel = PolicyStatusModel(id = "id1", status = PolicyStatusEnum.Started)
+
+  before {
+    reset(spyActor)
+  }
+
+  "SparkStreamingContextActor.launch" should {
+
+    "return failed policyModel when policy fails to start" in {
+      doReturn(Future(true))
+        .when(spyActor)
+        .isContextAvailable(policyStatusActorRef)
+      doNothing()
+        .when(spyActor)
+        .updatePolicy(policyModel, PolicyStatusEnum.Launched, policyStatusActorRef)
+      doReturn(None)
+        .when(spyActor)
+        .getStreamingContextActor(policyModel, policyStatusActorRef, streamingContextService, policyStatusActor.context)
+
+      for {
+        response <- spyActor.launch(policyModel, policyStatusActorRef, streamingContextService, policyStatusActor
+          .context)
+      } yield response should be(policyModel)
+
+      verify(spyActor, times(0)).startPolicy(sparkStreamingContextActorRef)
+      verify(spyActor, times(1)).updatePolicy(policyModel, PolicyStatusEnum.Failed, policyStatusActorRef)
+    }
+
+    "return policyModel when policy starts successfully" in {
+
+      doReturn(Future(true))
+        .when(spyActor)
+        .isContextAvailable(policyStatusActorRef)
+      doNothing()
+        .when(spyActor)
+        .updatePolicy(policyModel, PolicyStatusEnum.Launched, policyStatusActorRef)
+      doReturn(Option(sparkStreamingContextActorRef))
+        .when(spyActor)
+        .getStreamingContextActor(policyModel, policyStatusActorRef, streamingContextService, policyStatusActor.context)
+
+
+      for {
+        response <- spyActor.launch(policyModel, policyStatusActorRef, streamingContextService, policyStatusActor
+          .context)
+      } yield response should be(policyModel)
+
+      verify(spyActor, times(1)).startPolicy(Matchers.any(classOf[ActorRef]))
+      verify(spyActor, times(0)).updatePolicy(policyModel, PolicyStatusEnum.Failed, policyStatusActorRef)
+    }
+  }
+
+  "SparkStreamingContextActor.createNewPolicy" should {
+    "return exception when policy already exists" in {
+      doReturn(true)
+        .when(spyActor)
+        .existsByName(name = "testpolicy", id = None, curatorFramework = curatorFramework)
+
+      intercept[RuntimeException] {
+        spyActor.createNewPolicy(policy = policyModel,
+          policyStatusActor = policyStatusActorRef,
+          curatorFramework = curatorFramework,
+          streamingContextService = streamingContextService,
+          context = policyStatusActor.context)
+      }
+    }
+
+    "return valid aggregationPolicyModel when policy does not yet exist" in {
+      doReturn(false)
+        .when(spyActor)
+        .existsByName(name = "testpolicy", id = None, curatorFramework = curatorFramework)
+
+      doReturn((policyModel))
+        .when(spyActor)
+        .launchNewPolicy(policy = policyModel,
+          policyStatusActor = policyStatusActorRef,
+          curatorFramework = curatorFramework,
+          streamingContextService = streamingContextService,
+          context = policyStatusActor.context)
+
+      spyActor.createNewPolicy(policy = policyModel,
+        policyStatusActor = policyStatusActorRef,
+        curatorFramework = curatorFramework,
+        streamingContextService = streamingContextService,
+        context = policyStatusActor.context) should be(policyModel)
+
+      verify(spyActor, times(1)).launchNewPolicy(policy = policyModel,
+        policyStatusActor = policyStatusActorRef,
+        curatorFramework = curatorFramework,
+        streamingContextService = streamingContextService,
+        context = policyStatusActor.context)
+    }
+  }
+
+  "SparkStreamingContextActor.launchNewPolicy" should {
+    "return aggregationPolicyModel" in {
+      doReturn(policyModel)
+        .when(spyActor)
+        .policyWithId(policyModel)
+      doReturn(Future(Option(policyStatusModel)))
+        .when(spyActor)
+        .createPolicy(policyStatusActorRef, policyModel)
+      doNothing()
+        .when(spyActor)
+        .savePolicyInZk(policyModel, curatorFramework)
+      doReturn(Future(Success(policyModel)))
+        .when(spyActor)
+        .launch(policy = policyModel,
+          policyStatusActor = policyStatusActorRef,
+          streamingContextService = streamingContextService,
+          context = policyStatusActor.context)
+
+      spyActor.launchNewPolicy(policy = policyModel,
+        policyStatusActor = policyStatusActorRef,
+        curatorFramework = curatorFramework,
+        streamingContextService = streamingContextService,
+        context = policyStatusActor.context) should be(policyModel)
+
+      verify(spyActor, times(1)).savePolicyInZk(policy = policyModel, curatorFramework = curatorFramework)
+      verify(spyActor, times(1)).launch(policy = policyModel,
+        policyStatusActor = policyStatusActorRef,
+        streamingContextService = streamingContextService,
+        context = policyStatusActor.context)
+    }
+  }
+
+  "SparkStreamingContextActor.getStreamingContextActor" should {
+    "return ClusterLauncherActor" in {
+
+      SparktaConfig.initMainConfig(Option(mesosConfig), new MockConfigFactory(mesosConfig))
+
+      spyActor.getStreamingContextActor(getPolicyModel(id = "clusterPolicy"),
+        policyStatusActorRef,
+        streamingContextService,
+        policyStatusActor.context)
+
+      verify(spyActor, times(1)).getClusterLauncher(getPolicyModel(id = "clusterPolicy"), policyStatusActorRef,
+        policyStatusActor.context, "sparkStreamingContextActor-clusterPolicy")
+    }
+
+    "return LocalSparkStreamingContextActor" in {
+      SparktaConfig.initMainConfig(Option(localConfig), new MockConfigFactory(localConfig))
+      doNothing()
+        .when(spyActor)
+        .killPolicy(policyStatusActorRef, "sparkStreamingContextActor-localPolicy")
+
+      spyActor.getStreamingContextActor(getPolicyModel(id = "localPolicy"),
+        policyStatusActorRef,
+        streamingContextService,
+        policyStatusActor.context)
+
+      verify(spyActor, times(1)).getLocalLauncher(getPolicyModel(id = "localPolicy"), policyStatusActorRef,
+        streamingContextService, policyStatusActor.context, "sparkStreamingContextActor-localPolicy")
+    }
+  }
+}


### PR DESCRIPTION
Check when Sparta runs in **local/standalone** mode and avoid multiple policies run at the same time.

***given*** an instance of Sparta (local/standalone mode) with a started policy
***when*** you try to run other policy
***then*** return an error

***given*** an instance of Sparta (local/standalone mode) with a started policy named "A"
***when*** you try to commit a new policy named "B"
***then*** the new policy will be created but not launched

***given*** an instance of Sparta (cluster mode) with a started policy named "A"
***when*** you try to run other policy "B"
***then*** start policy "B" at the same time as "A"