### PR TITLE
[SPARKTA-361] Sparta with SSL

### DIFF
--- a/Docker/docker-entrypoint.sh
+++ b/Docker/docker-entrypoint.sh
@@ -19,5 +19,14 @@ fi
 if [[ "${EXECUTION_MODE}" == "yarn" ]]; then
    sed -i "s|sparkHome.*|sparkHome = \""${SPARK_HOME}"\"|" /etc/sds/sparta/application.conf
 fi
+if [[ "${SSH}" == "true" ]]; then
+   /usr/sbin/sshd -e
+fi
+if [[ "${SSL}" == "on" ]]; then
+   sed -i "s|ssl-encryption.*|ssl-encryption = \""${SSL}"\"|" /etc/sds/sparta/application.conf
+   sed -i "s|certificate-file.*|certificate-file = \""${CERTIFICATE_FILE}"\"|" /etc/sds/sparta/application.conf
+   sed -i "s|certificate-password.*|certificate-password = \""${CERTIFICATE_PASSWORD}"\"|" /etc/sds/sparta/application.conf
+fi
+
 /etc/init.d/sparta start
 tail -F /var/log/sds/sparta/sparta.log

--- a/dist/src/main/resources/application.conf
+++ b/dist/src/main/resources/application.conf
@@ -3,6 +3,8 @@ sparta {
   api {
     host = 0.0.0.0
     port = 9090
+    certificate-file = "/home/user/certifications/stratio.jks"
+    certificate-password = "stratio"
   }
 
   swagger {
@@ -76,4 +78,10 @@ sparta {
     streamingActorInstances = 3
   }
 
+}
+
+spray.can {
+  server {
+    ssl-encryption = "off"
+  }
 }

--- a/serving-api/src/main/resources/reference.conf
+++ b/serving-api/src/main/resources/reference.conf
@@ -1,16 +1,9 @@
-spray.routing {
-  verbose-error-messages = on
-  render-vanity-footer = no
-}
-spray.can {
-  verbose-error-messages = on
-}
-
 sparta {
-
   api {
-    host = 0.0.0.0
+    host = localhost
     port = 9090
+    certificate-file = "/home/user/certifications/stratio.jks"
+    certificate-password = "stratio"
   }
 
   swagger {
@@ -30,7 +23,7 @@ sparta {
     spark.master = "local[*]"
     spark.cores.max = 4
     spark.executor.memory = 1024m
-    spark.app.name = SPARTA
+    spark.app.name = SPARKTA
     spark.sql.parquet.binaryAsString = true
     spark.streaming.concurrentJobs = 1
     #spark.metrics.conf = /opt/sds/sparta/benchmark/src/main/resources/metrics.properties
@@ -87,5 +80,11 @@ sparta {
   akka {
     controllerActorInstances = 5
     streamingActorInstances = 3
+  }
+}
+
+spray.can {
+  server {
+    ssl-encryption = "off"
   }
 }

--- a/serving-api/src/main/scala/com/stratio/sparta/serving/api/Sparta.scala
+++ b/serving-api/src/main/scala/com/stratio/sparta/serving/api/Sparta.scala
@@ -28,6 +28,7 @@ object Sparta extends App with SLF4JLogging {
   SpartaConfig.initMainConfig()
   SpartaConfig.initDAOs
   SpartaConfig.initApiConfig()
+  SpartaConfig.initSprayConfig()
   SpartaConfig.initSwaggerConfig()
   SpartaHelper.initAkkaSystem(AppConstant.ConfigAppName)
   SpartaHelper.initPolicyContextStatus

--- a/serving-api/src/main/scala/com/stratio/sparta/serving/api/service/ssl/SSLSupport.scala
+++ b/serving-api/src/main/scala/com/stratio/sparta/serving/api/service/ssl/SSLSupport.scala
@@ -1,0 +1,49 @@
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stratio.sparkta.serving.api.ssl
+
+import java.io.FileInputStream
+import java.security.{KeyStore, SecureRandom}
+import javax.net.ssl.{KeyManagerFactory, SSLContext, TrustManagerFactory}
+
+import com.stratio.sparta.serving.core.SpartaConfig
+import spray.io._
+
+object SSLSupport {
+
+  implicit def sslContext: SSLContext = {
+    val keyStoreResource = SpartaConfig.apiConfig.get.getString("certificate-file")
+    val password = SpartaConfig.apiConfig.get.getString("certificate-password")
+
+    val keyStore = KeyStore.getInstance("jks")
+    keyStore.load(new FileInputStream(keyStoreResource), password.toCharArray)
+    val keyManagerFactory = KeyManagerFactory.getInstance("SunX509")
+    keyManagerFactory.init(keyStore, password.toCharArray)
+    val trustManagerFactory = TrustManagerFactory.getInstance("SunX509")
+    trustManagerFactory.init(keyStore)
+    val context = SSLContext.getInstance("TLS")
+    context.init(keyManagerFactory.getKeyManagers, trustManagerFactory.getTrustManagers, new SecureRandom)
+    context
+  }
+
+  implicit def sslEngineProvider: ServerSSLEngineProvider = {
+    ServerSSLEngineProvider { engine =>
+      engine.setEnabledCipherSuites(Array("TLS_RSA_WITH_AES_128_CBC_SHA"))
+      engine.setEnabledProtocols(Array( "TLSv1", "TLSv1.1", "TLSv1.2" ))
+      engine
+    }
+  }
+}

--- a/serving-core/src/main/scala/com/stratio/sparta/serving/core/constants/AppConstant.scala
+++ b/serving-core/src/main/scala/com/stratio/sparta/serving/core/constants/AppConstant.scala
@@ -34,6 +34,7 @@ object AppConstant {
   final val ConfigMesos = "mesos"
   final val ConfigYarn = "yarn"
   final val ConfigAkka = "akka"
+  final val ConfigSpray = "spray.can.server"
   final val ConfigSwagger = "swagger"
   final val ConfigZookeeper = "zookeeper"
   final val BaseZKPath = "stratio/sparta"


### PR DESCRIPTION
#### Description
As an user I want to configure a certificate in my configuration as follows:

```
spray.can {
    server {
      server-header = "sparta api"
      ssl-encryption = "on"
      ssl-tracing = "on"
      verbose-error-messages = "on"
    }
}

sparta {
  api {
    host = localhost
    port = 9090
    certificate-file = "/home/user/certificates/stratio.jks"
    certificate-password = "certificate password"
  }

  ......
```
Then sparta has ssl support: https://localhost:9090 and all requests are securized.

To generate a valid certification:
```
keytool -genkey -keyalg RSA -alias stratio -keystore stratio.jks -storepass stratio -validity 360 -keysize 2048
```
