### PR TITLE
[SPARKTA-522] Exclude /var in pom.xml

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -152,6 +152,7 @@
                                 <dir>/etc</dir>
                                 <dir>/etc/init.d</dir>
                                 <dir>/etc/default</dir>
+                                <dir>/var</dir>
                                 <dir>/var/run</dir>
                                 <dir>/var/log</dir>
                                 <dir>/opt</dir>


### PR DESCRIPTION
#### Description
Minor change to add /var as a path to exclude in dist pom.xml