### PR TITLE
[SPARTA-528] Unchecked errors not shown

### DIFF
--- a/dist/src/main/unix/files_and_dirs/bin/sparta.sh
+++ b/dist/src/main/unix/files_and_dirs/bin/sparta.sh
@@ -29,4 +29,4 @@ done
 # Set defatult values
 PIDFILE=${PIDFILE:-"/var/run/sds/sparta.pid"}
 
-bash $DIR/run >> /dev/null 2>&1 & echo $! >$PIDFILE
+bash $DIR/run >> /dev/null 2>/var/log/sds/sparta/sparta.log & echo $! >$PIDFILE


### PR DESCRIPTION
**Given** an installation of Sparta
**When** throws unchecked errors
**Then** they should be shown at `/var/log/sds/sparta/sparta.log`
