### PR TITLE
avoid web tests to be run twice

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -73,6 +73,9 @@
                             <goal>karma</goal>
                         </goals>
                         <phase>test</phase>
+			<configuration>
+              		    <skip.karma>${skipUTs}</skip.karma>
+            		</configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
this way we prevent web tests from running during unit and integration tests, saving time in jenkins and reducing the chance to produce an error