### PR TITLE
[SPARTA-530] field name too much descriptive

### DIFF
--- a/plugins/src/main/scala/com/stratio/sparta/plugin/output/kafka/producer/KafkaProducer.scala
+++ b/plugins/src/main/scala/com/stratio/sparta/plugin/output/kafka/producer/KafkaProducer.scala
@@ -54,6 +54,13 @@ object KafkaProducer {
     }
   }
 
+  private val getBoolean: ((Map[String, JSerializable], String, String) => String) = (properties, key, default) => {
+    properties.getString(key).toBoolean match {
+      case true => "1"
+      case _ => "0"
+    }
+  }
+
   private val getList: ((Map[String, JSerializable], String, String) => String) = (properties, key, default) => {
     val values = getAdditionalOptions(key, HostKey, PortKey, properties)
 
@@ -79,7 +86,7 @@ object KafkaProducer {
   private val mandatoryOptions: Map[String, ((Map[String, JSerializable], String, String) => AnyRef, String)] = Map(
     "metadata.broker.list" ->(getList, DefaultHostPort),
     "serializer.class" ->(getString, DefaultKafkaSerializer),
-    "request.required.acks" ->(getString, DefaultRequiredAcks),
+    "request.required.acks" ->(getBoolean, DefaultRequiredAcks),
     "producer.type" ->(getString, DefaultProducerType),
     "batch.num.messages" ->(getString, DefaultBatchNumMessages))
 

--- a/plugins/src/test/scala/com/stratio/sparta/plugin/output/kafka/KafkaProducerTest.scala
+++ b/plugins/src/test/scala/com/stratio/sparta/plugin/output/kafka/KafkaProducerTest.scala
@@ -43,7 +43,7 @@ class KafkaProducerTest extends FlatSpec with Matchers {
   val validProperties: Map[String, Serializable] = Map(
     "metadata.broker.list" -> """[{"host":"localhost","port":"9092"},{"host":"localhost2","port":"90922"}]""",
     "serializer.class" -> "kafka.serializer.StringEncoder",
-    "request.required.acks" -> 1,
+    "request.required.acks" -> "true",
     "producer.type" -> "async",
     "batch.num.messages" -> 200
   )

--- a/web/src/data-templates/output.json
+++ b/web/src/data-templates/output.json
@@ -595,11 +595,11 @@
     {
       "propertyId": "request.required.acks",
       "propertyName": "_REQUIRED_ACKS_",
-      "propertyType": "text",
-      "regexp": "0|1",
-      "default": "0",
-      "required": true,
-      "tooltip": "Specify whether producer waits for an acknowledgment from the broker (1), or not (0)",
+      "propertyType": "boolean",
+      "regexp": "true|false",
+      "default": false,
+      "required": false,
+      "tooltip": "Specify whether producer waits for an acknowledgment from the broker, or not",
       "qa": "fragment-details-kafka-request-required-acks"
     },
     {

--- a/web/src/languages/en-US.json
+++ b/web/src/languages/en-US.json
@@ -275,7 +275,7 @@
   "_SPARK_PROPERTY_VALUE_": "Value",
   "_KAFKA_PROPERTY_VALUE_": "Value",
   "_SERIALIZER_": "Serializer class for messages",
-  "_REQUIRED_ACKS_": "Specify whether kafka producer waits for an acknowledgement from the broker (1), or not (0)",
+  "_REQUIRED_ACKS_": "Required ACKs",
   "_KAFKA_HOST_": "Zookeeper host",
   "_KAFKA_PORT_": "Kafka port",
   "_PRODUCER_TYPE_": "Producer type (sync/async)",


### PR DESCRIPTION
**GIVEN** a running Sparta instance
**WHEN** you create a kafka output
**THEN** you can set the property "requiered ACKs" (before known as "Specify whether kafka producer waits for an acknowledgement from the broker (1), or not (0)") using checkbox (true/false) values instead of 0/1 values.

The documentation is already updated. Please check https://stratio.atlassian.net/wiki/display/SPARKTA/7.4+Outputs#id-7.4Outputs-8.4.9Kafka
