### PR TITLE
[SPARTA-360] [SPARTA-510] Integration with GoSec

### DIFF
--- a/Docker/docker-entrypoint.sh
+++ b/Docker/docker-entrypoint.sh
@@ -22,11 +22,6 @@ fi
 if [[ "${SSH}" == "true" ]]; then
    /usr/sbin/sshd -e
 fi
-if [[ "${SSL}" == "on" ]]; then
-   sed -i "s|ssl-encryption.*|ssl-encryption = \""${SSL}"\"|" /etc/sds/sparta/application.conf
-   sed -i "s|certificate-file.*|certificate-file = \""${CERTIFICATE_FILE}"\"|" /etc/sds/sparta/application.conf
-   sed -i "s|certificate-password.*|certificate-password = \""${CERTIFICATE_PASSWORD}"\"|" /etc/sds/sparta/application.conf
-fi
 
 /etc/init.d/sparta start
 tail -F /var/log/sds/sparta/sparta.log

--- a/dist/src/main/resources/application.conf
+++ b/dist/src/main/resources/application.conf
@@ -80,6 +80,24 @@ sparta {
 
 }
 
+oauth2 {
+  enable = "false"
+
+  url {
+    authorize = "https://server.domain:9005/cas/oauth2.0/authorize"
+    accessToken = "https://server.domain:9005/cas/oauth2.0/accessToken"
+    profile = "https://server.domain:9005/cas/oauth2.0/profile"
+    logout = "https://server.domain:9005/cas/logout"
+    callBack = "http://callback.domain:9090/login"
+    onLoginGoTo = "/"
+  }
+  client{
+    id = "userid"
+    secret = "usersecret"
+  }
+  cookieName="user"
+}
+
 spray.can {
   server {
     ssl-encryption = "off"

--- a/pom.xml
+++ b/pom.xml
@@ -184,8 +184,8 @@
         <scalatest.version>2.2.2</scalatest.version>
         <mockito.version>1.10.5</mockito.version>
         <spray.version>1.3.3</spray.version>
-        <akka.version>2.3.4-spark</akka.version>
         <spray.test.version>1.3.1</spray.test.version>
+        <akka.version>2.3.4-spark</akka.version>
         <json4s.version>3.2.10</json4s.version>
         <lucene.version>4.10.4</lucene.version>
         <jackson.version>2.4.4</jackson.version>
@@ -612,4 +612,12 @@
             </properties>
         </profile>
     </profiles>
+
+    <repositories>
+        <repository>
+            <id>sodio</id>
+            <name>sodio</name>
+            <url>http://sodio.stratio.com/nexus/content/groups/public</url>
+        </repository>
+    </repositories>
 </project>

--- a/serving-api/pom.xml
+++ b/serving-api/pom.xml
@@ -177,6 +177,21 @@
             <version>${spray.test.version}</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>com.stratio.spray.auth</groupId>
+            <artifactId>spray-oauth2-client_2.10</artifactId>
+            <version>0.2.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.spray</groupId>
+            <artifactId>spray-client_2.10</artifactId>
+            <version>${spray.version}</version>
+        </dependency>
+
+
+
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-streaming_${scala.binary.version}</artifactId>

--- a/serving-api/src/main/resources/reference.conf
+++ b/serving-api/src/main/resources/reference.conf
@@ -1,6 +1,7 @@
 sparta {
+
   api {
-    host = localhost
+    host = 0.0.0.0
     port = 9090
     certificate-file = "/home/user/certifications/stratio.jks"
     certificate-password = "stratio"
@@ -23,7 +24,7 @@ sparta {
     spark.master = "local[*]"
     spark.cores.max = 4
     spark.executor.memory = 1024m
-    spark.app.name = SPARKTA
+    spark.app.name = SPARTA
     spark.sql.parquet.binaryAsString = true
     spark.streaming.concurrentJobs = 1
     #spark.metrics.conf = /opt/sds/sparta/benchmark/src/main/resources/metrics.properties
@@ -81,6 +82,24 @@ sparta {
     controllerActorInstances = 5
     streamingActorInstances = 3
   }
+}
+
+oauth2 {
+  enable = "false"
+
+  url {
+    authorize = "https://server.domain:9005/cas/oauth2.0/authorize"
+    accessToken = "https://server.domain:9005/cas/oauth2.0/accessToken"
+    profile = "https://server.domain:9005/cas/oauth2.0/profile"
+    logout = "https://server.domain:9005/cas/logout"
+    callBack = "http://callback.domain:9090/login"
+    onLoginGoTo = "/"
+  }
+  client{
+    id = "userid"
+    secret = "usersecret"
+  }
+  cookieName="user"
 }
 
 spray.can {

--- a/serving-api/src/main/scala/com/stratio/sparta/serving/api/actor/SwaggerActor.scala
+++ b/serving-api/src/main/scala/com/stratio/sparta/serving/api/actor/SwaggerActor.scala
@@ -15,6 +15,8 @@
  */
 package com.stratio.sparta.serving.api.actor
 
+import com.stratio.sparkta.serving.api.service.http.{PolicyContextHttpService, TemplateHttpService}
+
 import scala.reflect.runtime.universe._
 
 import akka.actor.{ActorContext, ActorRef}

--- a/serving-api/src/main/scala/com/stratio/sparta/serving/api/headers/CacheSupport.scala
+++ b/serving-api/src/main/scala/com/stratio/sparta/serving/api/headers/CacheSupport.scala
@@ -1,0 +1,33 @@
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stratio.sparta.serving.api.headers
+
+import spray.http.HttpHeaders._
+import spray.http._
+import spray.routing._
+
+trait CacheSupport {
+
+  this: HttpService =>
+
+  private val CacheControlHeader = `Cache-Control`(CacheDirectives.`no-cache`)
+
+  def noCache[T]: Directive0 = mapRequestContext {
+    ctx => ctx.withHttpResponseHeadersMapped { headers =>
+      CacheControlHeader :: headers
+    }
+  }
+}

--- a/serving-api/src/main/scala/com/stratio/sparta/serving/api/headers/CorsSupport.scala
+++ b/serving-api/src/main/scala/com/stratio/sparta/serving/api/headers/CorsSupport.scala
@@ -1,0 +1,51 @@
+/**
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.stratio.sparta.serving.api.headers
+
+import spray.http.HttpHeaders._
+import spray.http.HttpMethods._
+import spray.http.{AllOrigins, HttpMethod, HttpMethods, HttpResponse}
+import spray.routing._
+
+trait CorsSupport {
+
+  this: HttpService =>
+
+  private final val MaxAge = 1728000
+
+  private val AllowOriginHeader = `Access-Control-Allow-Origin`(AllOrigins)
+  private val OptionsCorsHeaders = List(
+    `Access-Control-Allow-Headers`(
+      "Origin, X-Requested-With, Content-Type, Accept, Accept-Encoding, Accept-Language, Host, Referer, User-Agent"),
+    `Access-Control-Max-Age`(MaxAge))
+
+  def cors[T]: Directive0 = mapRequestContext {
+    ctx => ctx.withRouteResponseHandling({
+      case Rejected(x) if (ctx.request.method.equals(HttpMethods.OPTIONS) &&
+        !x.filter(_.isInstanceOf[MethodRejection]).isEmpty) => {
+          val allowedMethods: List[HttpMethod] = x.filter(_.isInstanceOf[MethodRejection]).map(rejection => {
+            rejection.asInstanceOf[MethodRejection].supported
+          })
+          ctx.complete(HttpResponse().withHeaders(
+            `Access-Control-Allow-Methods`(OPTIONS, allowedMethods: _*) :: AllowOriginHeader :: OptionsCorsHeaders
+          ))
+        }
+      }).withHttpResponseHeadersMapped { headers =>
+      AllowOriginHeader :: headers
+    }
+  }
+}

--- a/serving-api/src/main/scala/com/stratio/sparta/serving/api/service/http/AppStatusHttpService.scala
+++ b/serving-api/src/main/scala/com/stratio/sparta/serving/api/service/http/AppStatusHttpService.scala
@@ -16,7 +16,6 @@
 package com.stratio.sparta.serving.api.service.http
 
 import com.stratio.sparta.serving.api.constants.HttpConstant
-import com.stratio.sparta.serving.core.CuratorFactoryHolder
 import com.stratio.sparta.serving.core.exception.ServingCoreException
 import com.stratio.sparta.serving.core.models.ErrorModel
 import com.wordnik.swagger.annotations._

--- a/serving-api/src/main/scala/com/stratio/sparta/serving/api/service/http/BaseHttpService.scala
+++ b/serving-api/src/main/scala/com/stratio/sparta/serving/api/service/http/BaseHttpService.scala
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.stratio.sparta.serving.api.service.http
 
 import akka.actor.ActorRef

--- a/serving-api/src/main/scala/com/stratio/sparta/serving/api/service/http/FragmentHttpService.scala
+++ b/serving-api/src/main/scala/com/stratio/sparta/serving/api/service/http/FragmentHttpService.scala
@@ -27,6 +27,7 @@ import com.stratio.sparta.serving.core.actor.FragmentActor
 import com.stratio.sparta.serving.core.actor.FragmentActor._
 import com.stratio.sparta.serving.core.constants.AkkaConstant
 import com.stratio.sparta.serving.core.models.FragmentElementModel
+import com.stratio.spray.oauth2.client.OauthClient
 import com.wordnik.swagger.annotations._
 import spray.http.{HttpResponse, StatusCodes}
 import spray.routing.Route
@@ -36,10 +37,10 @@ import scala.util.{Failure, Success}
 
 @Api(value = HttpConstant.FragmentPath, description = "Operations over fragments: inputs and outputs that will be " +
   "included in a policy")
-trait FragmentHttpService extends BaseHttpService
-  with PolicyUtils {
+trait FragmentHttpService extends BaseHttpService with OauthClient with PolicyUtils {
 
-  override def routes: Route = findByTypeAndId ~ findAllByType ~ create ~ update ~ deleteByTypeAndId ~ findByTypeAndName
+  override def routes: Route =
+    findByTypeAndId ~ findAllByType ~ create ~ update ~ deleteByTypeAndId ~ findByTypeAndName
 
   @ApiOperation(value = "Find a fragment depending of its type and id.",
     notes = "Find a fragment depending of its type and id.",

--- a/serving-api/src/main/scala/com/stratio/sparta/serving/api/service/http/PolicyContextHttpService.scala
+++ b/serving-api/src/main/scala/com/stratio/sparta/serving/api/service/http/PolicyContextHttpService.scala
@@ -13,23 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.stratio.sparta.serving.api.service.http
+
+package com.stratio.sparkta.serving.api.service.http
 
 import akka.actor.ActorRef
 import akka.pattern.ask
-import com.stratio.sparta.serving.api.actor.SparkStreamingContextActor._
+import com.stratio.sparta.serving.api.actor.SparkStreamingContextActor
 import com.stratio.sparta.serving.api.constants.HttpConstant
+import com.stratio.sparta.serving.api.service.http.BaseHttpService
 import com.stratio.sparta.serving.core.actor.FragmentActor
 import com.stratio.sparta.serving.core.constants.AkkaConstant
 import com.stratio.sparta.serving.core.exception.ServingCoreException
 import com.stratio.sparta.serving.core.helpers.PolicyHelper
 import com.stratio.sparta.serving.core.models._
-import com.stratio.sparta.serving.core.policy.status.PolicyStatusActor.{FindAll, Response, Update}
+import com.stratio.sparta.serving.core.policy.status.PolicyStatusActor.{FindAll, _}
 import com.wordnik.swagger.annotations._
 import spray.http.{HttpResponse, StatusCodes}
 import spray.routing._
 
-import scala.concurrent.{Future, Await}
+import scala.concurrent.Await
 import scala.util.{Failure, Success, Try}
 
 @Api(value = HttpConstant.PolicyContextPath, description = "Operations about policy contexts.", position = 0)
@@ -116,7 +118,8 @@ trait PolicyContextHttpService extends BaseHttpService {
           validate(isValidAndMessageTuple._1, isValidAndMessageTuple._2) {
             complete {
               for {
-                policyResponseTry <- (supervisor ? Create(parsedP)).mapTo[Try[AggregationPoliciesModel]]
+                policyResponseTry <- (supervisor ? SparkStreamingContextActor.Create(parsedP))
+                  .mapTo[Try[AggregationPoliciesModel]]
               } yield {
                 policyResponseTry match {
                   case Success(policy) =>

--- a/serving-api/src/main/scala/com/stratio/sparta/serving/api/service/http/TemplateHttpService.scala
+++ b/serving-api/src/main/scala/com/stratio/sparta/serving/api/service/http/TemplateHttpService.scala
@@ -13,17 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.stratio.sparta.serving.api.service.http
+
+package com.stratio.sparkta.serving.api.service.http
 
 import akka.pattern.ask
+import com.stratio.sparta.serving.api.actor.TemplateActor._
 import com.stratio.sparta.serving.api.constants.HttpConstant
+import com.stratio.sparta.serving.api.service.http.BaseHttpService
 import com.stratio.sparta.serving.core.models.TemplateModel
 import com.wordnik.swagger.annotations._
 import spray.routing._
 
 import scala.concurrent.Await
 import scala.util.{Failure, Success}
-import com.stratio.sparta.serving.api.actor.TemplateActor._
 
 @Api(value = HttpConstant.TemplatePath,
   description = "Operations about templates. One template will have an abstract" +
@@ -83,7 +85,7 @@ trait TemplateHttpService extends BaseHttpService {
       message = HttpConstant.NotFoundMessage)
   ))
   def findByTypeAndName: Route = {
-    path(HttpConstant.TemplatePath / Segment / Segment ) { (templateType, name) =>
+    path(HttpConstant.TemplatePath / Segment / Segment) { (templateType, name) =>
       get {
         complete {
           val future = supervisor ? new FindByTypeAndName(templateType, name)

--- a/serving-api/src/test/scala/com/stratio/sparta/serving/api/service/http/PolicyContextHttpServiceTest.scala
+++ b/serving-api/src/test/scala/com/stratio/sparta/serving/api/service/http/PolicyContextHttpServiceTest.scala
@@ -17,6 +17,7 @@ package com.stratio.sparta.serving.api.service.http
 
 import akka.actor.ActorRef
 import akka.testkit.{TestActor, TestProbe}
+import com.stratio.sparkta.serving.api.service.http.PolicyContextHttpService
 import com.stratio.sparta.sdk.exception.MockException
 import com.stratio.sparta.serving.api.actor.SparkStreamingContextActor
 import com.stratio.sparta.serving.api.actor.SparkStreamingContextActor.Create

--- a/serving-api/src/test/scala/com/stratio/sparta/serving/api/service/http/TemplateHttpServiceTest.scala
+++ b/serving-api/src/test/scala/com/stratio/sparta/serving/api/service/http/TemplateHttpServiceTest.scala
@@ -16,6 +16,7 @@
 package com.stratio.sparta.serving.api.service.http
 
 import akka.actor.ActorRef
+import com.stratio.sparkta.serving.api.service.http.TemplateHttpService
 import com.stratio.sparta.sdk.exception.MockException
 import com.stratio.sparta.serving.api.actor.TemplateActor._
 import com.stratio.sparta.serving.api.constants.HttpConstant

--- a/test-at/src/test/scala/com/stratio/sparta/testat/SpartaATSuite.scala
+++ b/test-at/src/test/scala/com/stratio/sparta/testat/SpartaATSuite.scala
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.stratio.sparta.testat
 
 import java.io.{File, PrintStream}

--- a/web/src/scripts/controllers/policies.js
+++ b/web/src/scripts/controllers/policies.js
@@ -231,11 +231,22 @@
         vm.policiesData.list = result;
         updatePoliciesStatus();
 
-        checkPoliciesStatus = $interval(function () {
-          updatePoliciesStatus();
-        }, 5000);
+        if (vm.policiesData.list.length > 0) {
+          vm.checkPoliciesStatus = $interval(function () {
+            var policiesStatus = PolicyFactory.getPoliciesStatus();
 
+            policiesStatus.then(function (result) {
+              for (var i = 0; i < result.length; i++) {
+                var policyData = $filter('filter')(vm.policiesData.list, {'policy': {'id': result[i].id}}, true)[0];
+                if (policyData) {
+                  policyData.status = result[i].status;
+                }
+              }
+            });
+          }, 5000);
+        }
       }, function (error) {
+        $interval.cancel(vm.checkPoliciesStatus);
         $translate('_INPUT_ERROR_' + error.data.i18nCode + '_').then(function (value) {
           vm.successMessage = value;
           $timeout(function () {

--- a/web/src/scripts/factories/request-interceptor-factory.js
+++ b/web/src/scripts/factories/request-interceptor-factory.js
@@ -15,18 +15,33 @@
  */
 (function () {
   'use strict';
-
   angular
     .module('webApp')
-    .factory('requestInterceptor', function ($q, $rootScope) {
+    .factory('requestInterceptor', requestInterceptor);
 
-      return {
-        'responseError': function (rejection) {
-          if (rejection.status == 0) {
+  requestInterceptor.$inject = ['$q', '$rootScope', '$location', '$window'];
+
+  function requestInterceptor($q, $rootScope, $location, $window) {
+
+    return {
+      'responseError': function (rejection) {
+        switch (rejection.status) {
+          case 0:
+          {
             $rootScope.error = "_UNAVAILABLE_SERVER_ERROR_";
+            break;
           }
-          return $q.reject(rejection);
+          case 401:
+          {
+            var host = $location.protocol() + "://"+ $location.host() + ":" + $location.port()+ "/";
+            $window.location.href = host;
+            break;
+          }
+          default:
+            break;
         }
+        return $q.reject(rejection);
       }
-    })
+    }
+  }
 })();

--- a/web/test/factories/request-interceptor-factory.js
+++ b/web/test/factories/request-interceptor-factory.js
@@ -3,20 +3,37 @@ describe('policies.factories.request-interceptor-factory', function () {
   beforeEach(module('served/cube.json'));
   beforeEach(module('served/policyTemplate.json'));
 
-  var factory,srv, httpBackend, rootScope = null;
+  var factory, srv, httpBackend, rootScope, fragmentTypeIdJSON = null;
+  var windowObj = {location:{href: ''}};
+  var locationObj = {
+    protocol: function () {
+      return "http"
+    }, host: function () {
+      return "fakeHost"
+    }, port: function () {
+      return 8080
+    }
+  };
 
-  beforeEach(inject(function (_requestInterceptor_,_ApiFragmentService_, $httpBackend, $rootScope) {
+  beforeEach(module(function ($provide) {
+    $provide.value('$window', windowObj);
+    $provide.value('$location', locationObj);
+  }));
+
+  beforeEach(inject(function (_requestInterceptor_, _ApiFragmentService_, $httpBackend, $rootScope) {
     factory = _requestInterceptor_;
     httpBackend = $httpBackend;
     rootScope = $rootScope;
     srv = _ApiFragmentService_;
 
     httpBackend.when('GET', 'languages/en-US.json').respond({});
+    fragmentTypeIdJSON = {"type": "input", "id": "2581f20a-fd83-4315-be45-192bc5sEdFff"};
   }));
 
+
   it("should be able to update web error when a http request fails and its code is equal to 0", function () {
-    var fragmentTypeIdJSON = {"type":"input","id":"2581f20a-fd83-4315-be45-192bc5sEdFff"};
-    httpBackend.when('GET', '/fragment/input/'+fragmentTypeIdJSON.id).respond(0);
+
+    httpBackend.when('GET', '/fragment/input/' + fragmentTypeIdJSON.id).respond(0);
     spyOn(factory, 'responseError').and.callThrough();
     srv.getFragmentById().get(fragmentTypeIdJSON);
     rootScope.$digest();
@@ -24,4 +41,16 @@ describe('policies.factories.request-interceptor-factory', function () {
     expect(factory.responseError).toHaveBeenCalled();
     expect(rootScope.error).toBe("_UNAVAILABLE_SERVER_ERROR_");
   });
+
+  it("should be able to redirect to root path when a http request responds with a 401 code", function () {
+    httpBackend.when('GET', '/fragment/input/' + fragmentTypeIdJSON.id).respond(401);
+    spyOn(factory, 'responseError').and.callThrough();
+    srv.getFragmentById().get(fragmentTypeIdJSON);
+    rootScope.$digest();
+    httpBackend.flush();
+
+    expect(factory.responseError).toHaveBeenCalled();
+    var rootPath = locationObj.protocol() + "://" + locationObj.host() + ":" + locationObj.port() + "/";
+    expect(windowObj.location.href).toBe(rootPath);
+  })
 });


### PR DESCRIPTION
#### Description
With this feature you can configure a SSO server. For this purpose you need to follow these steps:

- Add in your /etc/hosts: 
```
10.200.0.56 gosec01.dev.stratio.com
127.0.0.1 anistal
```
- Download the certification from: https://gosec01.dev.stratio.com:9005/cas/login (export Gosec's SSL certification with chrome/firefox/etc.)
- Create cacerts file: 
```
keytool -import -alias ca -file Stratio\ Inc\ CA -keystore cacerts -storepass stratio
```
- Run sparta with this option -Djavax.net.ssl.trustStore=/path/to/cacerts
- Configure your application.conf with oauth configuration:
```
oauth2 {
  enable = "true"
  
  url {
    authorize = "https://gosec01.dev.stratio.com:9005/cas/oauth2.0/authorize"
    accessToken = "https://gosec01.dev.stratio.com:9005/cas/oauth2.0/accessToken"
    profile = "https://gosec01.dev.stratio.com:9005/cas/oauth2.0/profile"
    logout = "https://gosec01.dev.stratio.com:9005/cas/logout"
    callBack = "http://anistal:9090/login"
    onLoginGoTo = "/"
  }
  client{
    id = "anistal-client"
    secret = "fg345vfdefgh4gweb424rtvwg24"
  }
  cookieName="user"
}
```
- Starts sparta and go to the main page. When it appears you should be redirected to the login page
- Enter username and password: jmgomez/1234 (test user to check).
- The user is logged. If you need to do a logout: http://localhost:9090/logout. The cookie will be removed.

#### Definition of Done
**GIVEN** a running Sparta instance
**WHEN** you try to access to the main page
**THEN** you should be redirected to the SSO page

#### Documentation
https://stratio.atlassian.net/wiki/display/SPARKTA/6.+Configuration#id-6.Configuration-5.8.Oauth
