### PR TITLE
fix testsAT to use policyContext endpoint instead of policy to create policies

### DIFF
--- a/testsAT/src/test/resources/features/automated/endtoend/iSocketoCSV.feature
+++ b/testsAT/src/test/resources/features/automated/endtoend/iSocketoCSV.feature
@@ -9,23 +9,19 @@ Feature: Test policy with Socket input and CSV output
     And I wait '5' seconds
 
     # Add the policy
-    When I send a 'POST' request to '/policy' based on 'schemas/policies/iSocketoCSV.conf' as 'json' with:
+    When I send a 'POST' request to '/policyContext' based on 'schemas/policies/iSocketoCSV.conf' as 'json' with:
       | id | DELETE | N/A |
       | checkpointPath | UPDATE | /tmp/checkpoint |
       | input.configuration.hostname | UPDATE | @{IP.${IFACE}} |
       | input.configuration.port | UPDATE | 10666 |
       | outputs[0].configuration.path | UPDATE | ${CSV_PATH} |
     Then the service response status must be '200'.
-    And I save element '$.id' in environment variable 'previousPolicyID'
+    And I save element '$.policyId' in environment variable 'previousPolicyID'
     And I wait '10' seconds
-
-    # Start the policy
-    When I send a 'GET' request to '/policy/run/!{previousPolicyID}'
-    Then the service response status must be '200' and its response must contain the text '{"message":"Creating new context'
 
     # Send Data
     Given I send data from file 'src/test/resources/schemas/dataInput/info.csv' to socket
-    And I wait '10' seconds
+    And I wait '20' seconds
 
     # Check Data
     Given I open remote ssh connection to host '${SPARTA_HOST}' with user 'root' and password 'stratio'

--- a/testsAT/src/test/resources/features/automated/endtoend/iSocketoCassandra.feature
+++ b/testsAT/src/test/resources/features/automated/endtoend/iSocketoCassandra.feature
@@ -9,7 +9,7 @@ Feature: Test policy with Socket input and Cassandra output
     And I wait '5' seconds
 
     # Add the policy
-    When I send a 'POST' request to '/policy' based on 'schemas/policies/iSocketoCassandra.conf' as 'json' with:
+    When I send a 'POST' request to '/policyContext' based on 'schemas/policies/iSocketoCassandra.conf' as 'json' with:
       | id | DELETE | N/A |
       | checkpointPath | UPDATE | /tmp/checkpoint |
       | input.configuration.hostname | UPDATE | @{IP.${IFACE}} |
@@ -17,12 +17,8 @@ Feature: Test policy with Socket input and Cassandra output
       | outputs[0].configuration.connectionHost | UPDATE | ${CASSANDRA_HOST} |
       | outputs[0].configuration.connectionPort | UPDATE | ${CASSANDRA_PORT} |
     Then the service response status must be '200'.
-    And I save element '$.id' in environment variable 'previousPolicyID'
+    And I save element '$.policyId' in environment variable 'previousPolicyID'
     And I wait '10' seconds
-
-    # Start the policy
-    When I send a 'GET' request to '/policy/run/!{previousPolicyID}'
-    Then the service response status must be '200' and its response must contain the text '{"message":"Creating new context'
 
     # Send Data
     Given I send data from file 'src/test/resources/schemas/dataInput/info.csv' to socket

--- a/testsAT/src/test/resources/features/automated/endtoend/iSocketoElasticsearch.feature
+++ b/testsAT/src/test/resources/features/automated/endtoend/iSocketoElasticsearch.feature
@@ -9,7 +9,7 @@ Feature: Test policy with Socket input and Elasticsearch output
     And I wait '5' seconds
 
     # Add the policy
-    When I send a 'POST' request to '/policy' based on 'schemas/policies/iSocketoElasticsearch.conf' as 'json' with:
+    When I send a 'POST' request to '/policyContext' based on 'schemas/policies/iSocketoElasticsearch.conf' as 'json' with:
       | id | DELETE | N/A |
       | checkpointPath | UPDATE | /tmp/checkpoint |
       | input.configuration.hostname | UPDATE | @{IP.${IFACE}} |
@@ -17,12 +17,8 @@ Feature: Test policy with Socket input and Elasticsearch output
       | outputs[0].configuration.nodes[0].node | UPDATE | ${ES_NODE} |
       | outputs[0].configuration.clusterName       | UPDATE | elasticsearch              |
     Then the service response status must be '200'.
-    And I save element '$.id' in environment variable 'previousPolicyID'
+    And I save element '$.policyId' in environment variable 'previousPolicyID'
     And I wait '10' seconds
-
-    # Start the policy
-    When I send a 'GET' request to '/policy/run/!{previousPolicyID}'
-    Then the service response status must be '200' and its response must contain the text '{"message":"Creating new context'
 
     # Send Data
     Given I send data from file 'src/test/resources/schemas/dataInput/info.csv' to socket

--- a/testsAT/src/test/resources/features/automated/endtoend/iSocketoMongoDB.feature
+++ b/testsAT/src/test/resources/features/automated/endtoend/iSocketoMongoDB.feature
@@ -9,7 +9,7 @@ Feature: Test policy with Socket input and MongoDB output
     And I wait '5' seconds
 
     # Add the policy
-    When I send a 'POST' request to '/policy' based on 'schemas/policies/iSocketoMongoDB.conf' as 'json' with:
+    When I send a 'POST' request to '/policyContext' based on 'schemas/policies/iSocketoMongoDB.conf' as 'json' with:
       | id | DELETE | N/A |
       | checkpointPath | UPDATE | /tmp/checkpoint |
       | input.configuration.hostname | UPDATE | @{IP.${IFACE}} |
@@ -17,12 +17,8 @@ Feature: Test policy with Socket input and MongoDB output
       | outputs[0].configuration.hosts[0].host | UPDATE | ${MONGO_HOST} |
       | outputs[0].configuration.hosts[0].port | UPDATE | ${MONGO_PORT} |
     Then the service response status must be '200'.
-    And I save element '$.id' in environment variable 'previousPolicyID'
+    And I save element '$.policyId' in environment variable 'previousPolicyID'
     And I wait '10' seconds
-
-    # Start the policy
-    When I send a 'GET' request to '/policy/run/!{previousPolicyID}'
-    Then the service response status must be '200' and its response must contain the text '{"message":"Creating new context'
 
     # Send Data
     Given I send data from file 'src/test/resources/schemas/dataInput/info.csv' to socket


### PR DESCRIPTION
fix testsAT to use policyContext endpoint instead of policy to create policies, to make use of auto fragments generation and automatic startup of policy