### PR TITLE
[SPARTA-483] submiting policies to a Spark Standalone cluster

### DIFF
--- a/dist/src/main/resources/application.conf
+++ b/dist/src/main/resources/application.conf
@@ -43,7 +43,6 @@ sparta {
     master = "mesos://127.0.0.1:7077"
     spark.app.name = SPARTA
     spark.streaming.concurrentJobs = 1
-    spark.cores.max = 2
     spark.mesos.extra.cores = 1
     spark.mesos.coarse = true
     spark.executor.memory = 2G
@@ -62,7 +61,13 @@ sparta {
 
   standalone {
     sparkHome = ""
+    master = "spark://127.0.0.1:7077"
+    deployMode = cluster
+    numExecutors = 2
+    executorMemory = 2G
+    executorCores = 2
     spark.app.name = SPARTA
+    spark.serializer = org.apache.spark.serializer.KryoSerializer
   }
 
   zookeeper {

--- a/serving-api/src/main/resources/reference.conf
+++ b/serving-api/src/main/resources/reference.conf
@@ -22,7 +22,6 @@ sparta {
   local {
     spark.app.name = SPARTA
     spark.master = "local[*]"
-    spark.cores.max = 4
     spark.executor.memory = 1024m
     spark.app.name = SPARTA
     spark.sql.parquet.binaryAsString = true
@@ -45,12 +44,11 @@ sparta {
     numExecutors = 2
     master = "mesos://127.0.0.1:7077"
     spark.streaming.concurrentJobs = 1
-    spark.cores.max = 4
     spark.mesos.extra.cores = 1
     spark.mesos.coarse = true
-    spark.executor.memory = 4G
+    spark.executor.memory = 2G
     spark.driver.cores = 1
-    spark.driver.memory = 4G
+    spark.driver.memory = 1G
     spark.app.name = SPARTA
     #spark.metrics.conf = /opt/sds/sparta/benchmark/src/main/resources/metrics.properties
   }
@@ -68,6 +66,13 @@ sparta {
 
   standalone {
     sparkHome = ""
+    master = "spark://127.0.0.1:7077"
+    deployMode = cluster
+    numExecutors = 2
+    executorMemory = 2G
+    executorCores = 2
+    spark.app.name = SPARTA
+    spark.serializer = org.apache.spark.serializer.KryoSerializer
   }
 
   zookeeper {


### PR DESCRIPTION
**Given** a Sparta operating instance
**When** I set properties in order to run Sparta in standalone mode
**Then** Sparta should run and you could start any policy successfully

**NOTE**: some properties within reference.conf have been updated and/or remove.