### PR TITLE
[SPARTA-576] Sparta package change share folder permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.3 (April 2016)
+
+- Bugfix: Solved problem with permissions and owners.
+
 ## 0.9.2 (April 2016)
 
 - Bugfix: Fixed examples

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -255,16 +255,18 @@
                                             <path>src/main/unix/files_and_dirs/etc/default/sparta-functions</path>
                                             <toFile>/etc/default/sparta-functions</toFile>
                                             <attributes>
-                                                <user>sparta</user>
-                                                <group>stratio</group>
+                                                <user>root</user>
+                                                <group>root</group>
+                                                <mode>644</mode>
                                             </attributes>
                                         </copyFile>
                                         <copyFile>
                                             <path>src/main/unix/files_and_dirs/etc/default/sparta-variables</path>
                                             <toFile>/etc/default/sparta-variables</toFile>
                                             <attributes>
-                                                <user>sparta</user>
-                                                <group>stratio</group>
+                                                <user>root</user>
+                                                <group>root</group>
+                                                <mode>644</mode>
                                             </attributes>
                                         </copyFile>
                                         <copyFile>
@@ -291,16 +293,18 @@
                                             <path>src/main/unix/files_and_dirs/etc/default/sparta-functions</path>
                                             <toFile>/etc/default/sparta-functions</toFile>
                                             <attributes>
-                                                <user>sparta</user>
-                                                <group>stratio</group>
+                                                <user>root</user>
+                                                <group>root</group>
+                                                <mode>644</mode>
                                             </attributes>
                                         </copyFile>
                                         <copyFile>
                                             <path>src/main/unix/files_and_dirs/etc/default/sparta-variables</path>
                                             <toFile>/etc/default/sparta-variables</toFile>
                                             <attributes>
-                                                <user>sparta</user>
-                                                <group>stratio</group>
+                                                <user>root</user>
+                                                <group>root</group>
+                                                <mode>644</mode>
                                             </attributes>
                                         </copyFile>
                                         <copyFile>

--- a/dist/src/main/unix/scripts/postinst
+++ b/dist/src/main/unix/scripts/postinst
@@ -15,21 +15,21 @@ case "$1" in
     fi
 
     chown root:root /etc/init.d/sparta
+    chown root:root /etc/default/sparta-functions
+    chown root:root /etc/default/sparta-variables
 
     chown -R ${USER}:${GROUP} /etc/sds/sparta
-
-    chown ${USER}:${GROUP} /etc/default/sparta-functions
-    chown ${USER}:${GROUP} /etc/default/sparta-variables
-
     chown -R ${USER}:${GROUP} /var/log/sds/sparta
     chown -R ${USER}:${GROUP} /opt/sds/sparta
 
     chmod 755 /etc/init.d/sparta
-
-    chmod 750 /etc/sds/sparta
-    chmod 775 /var/log/sds/sparta
-    chmod 750 /opt/sds/sparta
+    chmod 755 /etc/sds/sparta
+    chmod 755 /var/log/sds/sparta
+    chmod 755 /opt/sds/sparta
     chmod 750 /opt/sds/sparta/bin/*
+    
+    chmod 644 /etc/default/sparta-functions
+    chmod 644 /etc/default/sparta-variables
 
     update-rc.d sparta defaults
   ;;


### PR DESCRIPTION
#### Description
When installing sparta the files should have these permissions:
root:stratio (775):
/etc/sds
/opt/sds
/var/log/sds
/var/sds
/var/run/sds

sparta:stratio (755):
/etc/sds/sparta
/var/log/sds/sparta
/opt/sds/sparta

root:root (644):
/etc/default/sparta-functions
/etc/default/sparta-variables