### PR TITLE
[SPARTA-592] add yarn-site.xml as hadoop resource

### DIFF
--- a/driver/src/main/scala/com/stratio/sparta/driver/util/HdfsUtils.scala
+++ b/driver/src/main/scala/com/stratio/sparta/driver/util/HdfsUtils.scala
@@ -60,9 +60,11 @@ object HdfsUtils extends SLF4JLogging {
     val hadoopConfDir = System.getenv("HADOOP_CONF_DIR")
     val hdfsCoreSitePath = new Path(s"$hadoopConfDir/core-site.xml")
     val hdfsHDFSSitePath = new Path(s"$hadoopConfDir/hdfs-site.xml")
+    val yarnSitePath = new Path(s"$hadoopConfDir/yarn-site.xml")
 
     conf.addResource(hdfsCoreSitePath)
     conf.addResource(hdfsHDFSSitePath)
+    conf.addResource(yarnSitePath)
 
     log.debug(s"Configuring HDFS with master: ${conf.get(DefaultFSProperty)} and user: $user")
     val defaultUri = FileSystem.getDefaultUri(conf)


### PR DESCRIPTION
**Given** a Sparta instance using yarn mode
**When** you start a policy
**Then** the policy should run successfully, connect to HDFS and write within /user/stratio/sparta/<policy-id> with no errors