### PR TITLE
SPARTA-623 Error trace is not giving enought information

### DIFF
--- a/driver/src/main/scala/com/stratio/sparta/driver/SpartaJob.scala
+++ b/driver/src/main/scala/com/stratio/sparta/driver/SpartaJob.scala
@@ -391,6 +391,8 @@ object SpartaJob extends SLF4JLogging with SpartaSerializer {
     ex.getCause match {
       case cause: ClassNotFoundException =>
         log.error("The component couldn't be found in classpath. Please check the type.")
+      case _ =>
+        log.error("Error instantiating policy component:", ex)
     }
     saveErrorZK(policyId, code)
     new IllegalArgumentException(message, ex)

--- a/project/scalastyle_config.xml
+++ b/project/scalastyle_config.xml
@@ -33,7 +33,7 @@
  </check>
  <check level="error" class="org.scalastyle.file.HeaderMatchesChecker" enabled="true">
   <parameters>
-   <parameter name="header"><![CDATA[/**
+   <parameter name="header"><![CDATA[/*
  * Copyright (C) 2015 Stratio (http://stratio.com)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
**Given** a policy with a KafkaDirect input
**When** Kafka service is not up
**Then** it should throw an exception giving the croncrete cause

**Given** a policy with a KafkaDirect input
**When** Kafka service is not up
**Then** it should **not** give following trace:

> LocalSparkStreamingContextActor:63 - null
> scala.MatchError: null ....

Fixed also scalastyle. Headers were giving errors