### PR TITLE
SPARTA-617 Example scripts do not work properly due to an incorrect syntax

### DIFF
--- a/examples/policies/fragments/CassandraFragment.json
+++ b/examples/policies/fragments/CassandraFragment.json
@@ -1,8 +1,8 @@
 {
   "fragmentType": "output",
   "name": "Cassandra",
-  "description": "Cassandra output",
-  "shortDescription": "Cassandra output",
+  "description": "The Apache Cassandra database is the right choice when you need scalability and high availability without compromising performance. Linear scalability and proven fault-tolerance on commodity hardware or cloud infrastructure make it the perfect platform for mission-critical data.",
+  "shortDescription": "The Cassandra output uses the generic implementation with DataFrames.",
   "element": {
     "name": "out-cassandra",
     "type": "Cassandra",

--- a/examples/policies/fragments/ElasticSearchFragment.json
+++ b/examples/policies/fragments/ElasticSearchFragment.json
@@ -1,8 +1,8 @@
 {
   "fragmentType": "output",
   "name": "Elasticsearch",
-  "description": "Elasticsearch output",
-  "shortDescription": "Elasticsearch ",
+  "description": "Elasticsearch is a search server based on Lucene. It provides a distributed, multitenant-capable full-text search engine with a RESTful web interface and schema-free JSON documents.",
+  "shortDescription": "The Elasticsearch output uses the generic implementation with DataFrames.",
   "element": {
     "name": "out-Elasticsearch",
     "type": "ElasticSearch",

--- a/examples/policies/fragments/MongoFragment.json
+++ b/examples/policies/fragments/MongoFragment.json
@@ -1,8 +1,8 @@
 {
   "fragmentType": "output",
   "name": "MongoDB",
-  "description": "MongoDB output",
-  "shortDescription": "MongoDB output",
+  "description": "MongoDB is an open-source document database that provides high performance, high availability, and automatic scaling.",
+  "shortDescription": "MongoDB is an open-source document database, and the leading NoSQL database.",
   "element": {
     "name": "out-Mongo",
     "type": "MongoDb",

--- a/examples/policies/fragments/WebSocketFragment.json
+++ b/examples/policies/fragments/WebSocketFragment.json
@@ -1,8 +1,8 @@
 {
   "fragmentType": "input",
   "name": "WebSocket",
-  "description": "websocket input",
-  "shortDescription": "websocket input",
+  "description": "WebSocket is a protocol providing full-duplex communication channels over a single TCP connection.",
+  "shortDescription": "WebSocket is a protocol providing full-duplex communication channels over a single TCP connection.",
   "element": {
     "name": "in-websocket",
     "type": "WebSocket",

--- a/examples/scripts/loadExampleConfiguration_Cassandra.sh
+++ b/examples/scripts/loadExampleConfiguration_Cassandra.sh
@@ -5,7 +5,7 @@ FRAGMENT=$(curl -sX GET -H "Content-Type: application/json" localhost:9090/fragm
 if [ "$FRAGMENT" == "null" ]; then
   INPUT=$(curl -sX POST -H "Content-Type: application/json" --data @../policies/fragments/WebSocketFragment.json localhost:9090/fragment | jq '.id' | sed -e "s/\"//g")
 else
-  INPUT = $(echo "$FRAGMENT" | tr -d '"')
+  INPUT=$(echo "$FRAGMENT" | tr -d '"')
 fi
 echo $INPUT
 
@@ -14,5 +14,5 @@ echo $OUTPUT
 
 cat ../policies/fragments/IWebSocket-OCassandra.json|sed -e "s/_input_id_/$INPUT/g"|sed -e "s/_output_id_/$OUTPUT/g" >temp.json
 
-POL=$(curl -sX POST -H "Content-Type: application/json" --data @./temp.json  localhost:9090/policy |jq '.id'| sed -e "s/\"//g")
+POL=$(curl -X POST -H "Content-Type: application/json" --data @./temp.json  localhost:9090/policy |jq '.id'| sed -e "s/\"//g")
 echo $POL

--- a/examples/scripts/loadExampleConfiguration_Elasticsearch.sh
+++ b/examples/scripts/loadExampleConfiguration_Elasticsearch.sh
@@ -1,10 +1,11 @@
+#!/usr/bin/env bash
 
 FRAGMENT=$(curl -sX GET -H "Content-Type: application/json" localhost:9090/fragment/input/name/websocket | jq '.id')
 
 if [ "$FRAGMENT" == "null" ]; then
   INPUT=$(curl -sX POST -H "Content-Type: application/json" --data @../policies/fragments/WebSocketFragment.json localhost:9090/fragment | jq '.id' | sed -e "s/\"//g")
 else
-  INPUT = $(echo "$FRAGMENT" | tr -d '"')
+  INPUT=$(echo "$FRAGMENT" | tr -d '"')
 fi
 echo $INPUT
 
@@ -13,5 +14,5 @@ echo $OUTPUT
 
 cat ../policies/fragments/IWebSocket-OElasticsearch.json|sed -e "s/_input_id_/$INPUT/g"|sed -e "s/_output_id_/$OUTPUT/g" >temp.json
 
-POL=$(curl -X POST -H "Content-Type: application/json" --data @./temp.json  localhost:9090/policy)
+POL=$(curl -X POST -H "Content-Type: application/json" --data @./temp.json  localhost:9090/policy |jq '.id'| sed -e "s/\"//g")
 echo $POL

--- a/examples/scripts/loadExampleConfiguration_Mongo.sh
+++ b/examples/scripts/loadExampleConfiguration_Mongo.sh
@@ -5,7 +5,7 @@ FRAGMENT=$(curl -sX GET -H "Content-Type: application/json" localhost:9090/fragm
 if [ "$FRAGMENT" == "null" ]; then
   INPUT=$(curl -sX POST -H "Content-Type: application/json" --data @../policies/fragments/WebSocketFragment.json localhost:9090/fragment | jq '.id' | sed -e "s/\"//g")
 else
-  INPUT = $(echo "$FRAGMENT" | tr -d '"')
+  INPUT=$(echo "$FRAGMENT" | tr -d '"')
 fi
 echo $INPUT
 
@@ -14,5 +14,5 @@ echo $OUTPUT
 
 cat ../policies/fragments/IWebSocket-OMongo.json|sed -e "s/_input_id_/$INPUT/g"|sed -e "s/_output_id_/$OUTPUT/g" >temp.json
 
-POL=$(curl -X POST -H "Content-Type: application/json" --data @./temp.json  localhost:9090/policy)
+POL=$(curl -X POST -H "Content-Type: application/json" --data @./temp.json  localhost:9090/policy |jq '.id'| sed -e "s/\"//g")
 echo $POL


### PR DESCRIPTION
**Given** a Sparta installation with no inputs, outputs or policies
**When** run the 3 scripts located at /opt/sds/sparta/examples/scripts
**Then** it should register 1 input, 3 outputs and 3 policies