### PR TITLE
[SPARTA-638] [SERVING-CORE] [SERVING-API] Update related policies when one fragment are modified

### DIFF
--- a/driver/src/main/scala/com/stratio/sparta/driver/SpartaClusterJob.scala
+++ b/driver/src/main/scala/com/stratio/sparta/driver/SpartaClusterJob.scala
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.stratio.sparta.driver
 
 import akka.actor.{ActorSystem, Props}
@@ -59,8 +60,7 @@ object SpartaClusterJob extends SpartaSerializer {
       val policyZk = getPolicyFromZookeeper(policyId, curatorFramework)
       implicit val system = ActorSystem(policyId)
       val fragmentActor = system.actorOf(Props(new FragmentActor(curatorFramework)), AkkaConstant.FragmentActor)
-      val policy = PolicyHelper.parseFragments(
-        PolicyHelper.fillFragments(policyZk, fragmentActor, timeout))
+      val policy = PolicyHelper.getPolicyWithFragments(policyZk, fragmentActor)
       val policyStatusActor = system.actorOf(Props(new PolicyStatusActor(curatorFramework)),
         AkkaConstant.PolicyStatusActor)
 

--- a/driver/src/test/scala/com/stratio/sparta/driver/test/cube/CubeTest.scala
+++ b/driver/src/test/scala/com/stratio/sparta/driver/test/cube/CubeTest.scala
@@ -13,21 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
-  * Copyright (C) 2016 Stratio (http://stratio.com)
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  * http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-  */
+
 
 package com.stratio.sparta.driver.test.cube
 

--- a/plugins/src/test/scala/com/stratio/sparta/plugin/field/datetime/DateTimeFieldTest.scala
+++ b/plugins/src/test/scala/com/stratio/sparta/plugin/field/datetime/DateTimeFieldTest.scala
@@ -13,21 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
-  * Copyright (C) 2016 Stratio (http://stratio.com)
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  * http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-  */
+
 
 package com.stratio.sparta.plugin.field.datetime
 

--- a/sdk/src/main/scala/com/stratio/sparta/sdk/TimeConfig.scala
+++ b/sdk/src/main/scala/com/stratio/sparta/sdk/TimeConfig.scala
@@ -13,21 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
-  * Copyright (C) 2016 Stratio (http://stratio.com)
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  * http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-  */
+
 
 package com.stratio.sparta.sdk
 

--- a/serving-api/src/main/scala/com/stratio/sparta/serving/api/constants/ActorsConstant.scala
+++ b/serving-api/src/main/scala/com/stratio/sparta/serving/api/constants/ActorsConstant.scala
@@ -13,21 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
-  * Copyright (C) 2016 Stratio (http://stratio.com)
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  * http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-  */
+
 
 package com.stratio.sparta.serving.api.constants
 

--- a/serving-core/src/main/scala/com/stratio/sparta/serving/core/CuratorFactoryHolder.scala
+++ b/serving-core/src/main/scala/com/stratio/sparta/serving/core/CuratorFactoryHolder.scala
@@ -13,21 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
-  * Copyright (C) 2016 Stratio (http://stratio.com)
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  * http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-  */
+
 
 package com.stratio.sparta.serving.core
 

--- a/serving-core/src/main/scala/com/stratio/sparta/serving/core/helpers/JarsHelper.scala
+++ b/serving-core/src/main/scala/com/stratio/sparta/serving/core/helpers/JarsHelper.scala
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.stratio.sparta.serving.core.helpers
 
 import java.io.File

--- a/serving-core/src/main/scala/com/stratio/sparta/serving/core/helpers/OperationsHelper.scala
+++ b/serving-core/src/main/scala/com/stratio/sparta/serving/core/helpers/OperationsHelper.scala
@@ -13,21 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
-  * Copyright (C) 2016 Stratio (http://stratio.com)
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  * http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-  */
 
 package com.stratio.sparta.serving.core.helpers
 

--- a/serving-core/src/main/scala/com/stratio/sparta/serving/core/helpers/PolicyHelper.scala
+++ b/serving-core/src/main/scala/com/stratio/sparta/serving/core/helpers/PolicyHelper.scala
@@ -13,21 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
-  * Copyright (C) 2016 Stratio (http://stratio.com)
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  * http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-  */
 
 package com.stratio.sparta.serving.core.helpers
 
@@ -35,6 +20,7 @@ import akka.actor.ActorRef
 import akka.pattern.ask
 import akka.util.Timeout
 import com.stratio.sparta.serving.core.actor.FragmentActor.{FindByTypeAndId, ResponseFragment}
+import com.stratio.sparta.serving.core.constants.AkkaConstant
 import com.stratio.sparta.serving.core.models.FragmentType._
 import com.stratio.sparta.serving.core.models._
 
@@ -42,16 +28,28 @@ import scala.concurrent.Await
 import scala.util.{Failure, Success}
 
 /**
-  * Helper with operations over policies and policy fragments.
-  */
+ * Helper with operations over policies and policy fragments.
+ */
 object PolicyHelper {
 
   /**
-    * If the policy has fragments, it tries to parse them and depending of its type it composes input/outputs/etc.
-    *
-    * @param apConfig with the policy.
-    * @return a parsed policy with fragments included in input/outputs.
-    */
+   * Extract the policy with the updated fragments and added as inputs and outputs
+   *
+   * @param policy        the input policy model
+   * @param fragmentActor actor necessary to find fragments from the repository
+   * @param timeout       the limited time for the ask pattern in akka
+   * @return the policy with the correct fragments
+   */
+  def getPolicyWithFragments(policy: AggregationPoliciesModel, fragmentActor: ActorRef)
+                            (implicit timeout: Timeout): AggregationPoliciesModel =
+    parseFragments(fillFragments(policy, fragmentActor))
+
+  /**
+   * If the policy has fragments, it tries to parse them and depending of its type it composes input/outputs/etc.
+   *
+   * @param apConfig with the policy.
+   * @return a parsed policy with fragments included in input/outputs.
+   */
   def parseFragments(apConfig: AggregationPoliciesModel): AggregationPoliciesModel = {
 
     val fragmentInputs = getFragmentFromType(apConfig.fragments, FragmentType.input)
@@ -63,19 +61,16 @@ object PolicyHelper {
   }
 
   /**
-    * The policy only has fragments with its name and type. When this method is called it finds the full fragment in
-    * ZK and fills the rest of the fragment.
-    *
-    * @param apConfig with the policy.
-    * @return a fragment with all fields filled.
-    */
-  def fillFragments(apConfig: AggregationPoliciesModel,
-                    actor: ActorRef,
-                    currentTimeout: Timeout): AggregationPoliciesModel = {
-    implicit val timeout = currentTimeout
-
+   * The policy only has fragments with its name and type. When this method is called it finds the full fragment in
+   * ZK and fills the rest of the fragment.
+   *
+   * @param apConfig with the policy.
+   * @return a fragment with all fields filled.
+   */
+  def fillFragments(apConfig: AggregationPoliciesModel, fragmentActor: ActorRef)
+                   (implicit timeout: Timeout): AggregationPoliciesModel = {
     val currentFragments: Seq[FragmentElementModel] = apConfig.fragments.map(fragment => {
-      val future = actor ? new FindByTypeAndId(fragment.fragmentType, fragment.id.get)
+      val future = fragmentActor ? new FindByTypeAndId(fragment.fragmentType, fragment.id.get)
       Await.result(future, timeout.duration) match {
         case ResponseFragment(Failure(exception)) => throw exception
         case ResponseFragment(Success(fragment)) => fragment
@@ -85,12 +80,12 @@ object PolicyHelper {
   }
 
   /**
-    * This method tries to parse an input/output from a policy to a FragmentModelElement
-    *
-    * @param policy       AggregationPolicy to parse from
-    * @param fragmentType type of fragment to parse to
-    * @return a valid fragment element (input/output)
-    */
+   * This method tries to parse an input/output from a policy to a FragmentModelElement
+   *
+   * @param policy       AggregationPolicy to parse from
+   * @param fragmentType type of fragment to parse to
+   * @return a valid fragment element (input/output)
+   */
   def populateFragmentFromPolicy(policy: AggregationPoliciesModel, fragmentType: `type`): Seq[FragmentElementModel] =
     fragmentType match {
       case FragmentType.input => Seq(policy.input.get.parseToFragment(fragmentType))
@@ -106,12 +101,12 @@ object PolicyHelper {
   }
 
   /**
-    * Depending of where is the input it tries to get a input. If not an exceptions is thrown.
-    *
-    * @param fragmentsInputs with inputs extracted from the fragments.
-    * @param inputs          with the current configuration.
-    * @return A policyElementModel with the input.
-    */
+   * Depending of where is the input it tries to get a input. If not an exceptions is thrown.
+   *
+   * @param fragmentsInputs with inputs extracted from the fragments.
+   * @param inputs          with the current configuration.
+   * @return A policyElementModel with the input.
+   */
   private def getCurrentInput(fragmentsInputs: Seq[FragmentElementModel],
                               inputs: Option[PolicyElementModel]): PolicyElementModel = {
 

--- a/serving-core/src/main/scala/com/stratio/sparta/serving/core/helpers/ResourceManagerLink.scala
+++ b/serving-core/src/main/scala/com/stratio/sparta/serving/core/helpers/ResourceManagerLink.scala
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package com.stratio.sparta.serving.core.helpers
 
 import java.net.Socket

--- a/serving-core/src/main/scala/com/stratio/sparta/serving/core/models/PolicyElementModel.scala
+++ b/serving-core/src/main/scala/com/stratio/sparta/serving/core/models/PolicyElementModel.scala
@@ -13,21 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
-  * Copyright (C) 2016 Stratio (http://stratio.com)
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  * http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-  */
+
 
 package com.stratio.sparta.serving.core.models
 

--- a/serving-core/src/test/scala/com/stratio/sparta/serving/core/helpers/OperationsHelperTest.scala
+++ b/serving-core/src/test/scala/com/stratio/sparta/serving/core/helpers/OperationsHelperTest.scala
@@ -13,21 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
-  * Copyright (C) 2016 Stratio (http://stratio.com)
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  * http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-  */
+
 
 package com.stratio.sparta.serving.core.helpers
 

--- a/test-at/src/test/scala/com/stratio/sparta/testat/internal/ISocketOElasticsearchJsonAT.scala
+++ b/test-at/src/test/scala/com/stratio/sparta/testat/internal/ISocketOElasticsearchJsonAT.scala
@@ -13,21 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
-  * Copyright (C) 2016 Stratio (http://stratio.com)
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  * http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-  */
+
 
 package com.stratio.sparta.testat.internal
 

--- a/test-at/src/test/scala/com/stratio/sparta/testat/outputs/ISocketOElasticsearchOperatorsIT.scala
+++ b/test-at/src/test/scala/com/stratio/sparta/testat/outputs/ISocketOElasticsearchOperatorsIT.scala
@@ -13,21 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/**
-  * Copyright (C) 2016 Stratio (http://stratio.com)
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License");
-  * you may not use this file except in compliance with the License.
-  * You may obtain a copy of the License at
-  *
-  * http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing, software
-  * distributed under the License is distributed on an "AS IS" BASIS,
-  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-  * See the License for the specific language governing permissions and
-  * limitations under the License.
-  */
+
 
 package com.stratio.sparta.testat.outputs
 


### PR DESCRIPTION
Due to update one input or output in Sparta UI it is neccesary update and modify the related policies

**Given** one updated input or output
**When** the sparta server receive the updated fragment
**Then** the policies that include the updated fragment should be modified with the new data