### PR TITLE
[SPARTA-645] Zookeeper offset path

### DIFF
--- a/plugins/src/main/scala/com/stratio/sparta/plugin/input/kafka/KafkaBase.scala
+++ b/plugins/src/main/scala/com/stratio/sparta/plugin/input/kafka/KafkaBase.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stratio.sparta.plugin.input.kafka
+
+import java.io.{Serializable => JSerializable}
+
+import com.stratio.sparta.sdk.ValidatingPropertyMap._
+
+trait KafkaBase {
+
+  def getZkConnectionConfs(
+                            properties: Map[String, JSerializable],
+                            key: String,
+                            defaultHost: String,
+                            defaultPort: String,
+                            zookeeperPath: String):
+  (String, String) = {
+    val hostList = properties.getMapFromJsoneyString(key)
+    val hosts = (for {
+      hostConfig <- hostList
+      host =  hostConfig.get("host").getOrElse(defaultHost)
+      port =  hostConfig.get("port").getOrElse(defaultPort)
+    } yield s"$host:$port").mkString(",")
+
+    val fullConnectionPath = if (zookeeperPath.isEmpty) hosts else s"$hosts/$zookeeperPath"
+    val validatedZookeeperPath = fullConnectionPath.replaceAll("//", "/")
+
+    (key.toString, validatedZookeeperPath)
+  }
+
+}

--- a/plugins/src/main/scala/com/stratio/sparta/plugin/output/kafka/producer/KafkaProducer.scala
+++ b/plugins/src/main/scala/com/stratio/sparta/plugin/output/kafka/producer/KafkaProducer.scala
@@ -18,6 +18,7 @@ package com.stratio.sparta.plugin.output.kafka.producer
 import java.io.{Serializable => JSerializable}
 import java.util.Properties
 
+import com.stratio.sparta.plugin.input.kafka.KafkaBase
 import com.stratio.sparta.sdk.ValidatingPropertyMap._
 import kafka.producer.{KeyedMessage, Producer, ProducerConfig}
 
@@ -32,7 +33,7 @@ trait KafkaProducer {
   }
 }
 
-object KafkaProducer {
+object KafkaProducer extends KafkaBase {
 
   private val DefaultHostPort: String = "localhost:9092"
   private val DefaultKafkaSerializer: String = "kafka.serializer.StringEncoder"
@@ -40,8 +41,12 @@ object KafkaProducer {
   private val DefaultProducerType = "sync"
   private val DefaultBatchNumMessages = "200"
   private val DefaultPropertiesKey = "kafkaProperties"
+  private val DefaultZookeeperPath = ""
+  private val DefaultHost = "localhost"
+  private val DefaultPort = "2181"
   private val PropertiesKey = "kafkaPropertyKey"
   private val PropertiesValue = "kafkaPropertyValue"
+
   private val HostKey = "host"
   private val PortKey = "port"
 
@@ -123,6 +128,13 @@ object KafkaProducer {
   private[kafka] def createProducer(properties: Map[String, JSerializable]): Producer[String, String] = {
     val props = extractOptions(properties, mandatoryOptions)
     addOptions(getAdditionalOptions(DefaultPropertiesKey, PropertiesKey, PropertiesValue, properties), props)
+    if (properties.contains("zookeeper.connect")) {
+      val zookeeperPath = properties.getString("zookeeper.path", DefaultZookeeperPath)
+      addOptions(
+        Map(getZkConnectionConfs(properties, "zookeeper.connect", DefaultHost, DefaultPort, zookeeperPath)), props
+      )
+    }
+
     val producerConfig = new ProducerConfig(props)
     new Producer[String, String](producerConfig)
   }

--- a/plugins/src/test/scala/com/stratio/sparta/plugin/input/kafka/getZkConnectionConfTest.scala
+++ b/plugins/src/test/scala/com/stratio/sparta/plugin/input/kafka/getZkConnectionConfTest.scala
@@ -15,7 +15,8 @@
  */
 package com.stratio.sparta.plugin.input.kafka
 
-import com.stratio.sparta.plugin.input.kafka.KafkaInput
+import java.io.Serializable
+
 import com.stratio.sparta.sdk.JsoneyString
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
@@ -29,41 +30,73 @@ class getZkConnectionConfTest extends WordSpec with Matchers {
 
     "return a chain (zookeper:conection , host:port)" in {
       val conn = """[{"host": "localhost", "port": "2181"}]"""
-      val input = new KafkaInput(Map("zookeeper.connect" -> JsoneyString(conn)))
-      input.getZkConnectionConfs("zookeeper.connect", "localhost", "2181") should
+      val props = Map("zookeeper.connect" -> JsoneyString(conn), "zookeeper.path" -> "/")
+      val input = new KafkaInput(props)
+
+      input.getZkConnectionConfs(props, "zookeeper.connect", "localhost", "2181", "") should
         be("zookeeper.connect", "localhost:2181")
+    }
+
+    "return a chain (zookeper:conection , host:port, zookeeper.path:path)" in {
+      val conn = """[{"host": "localhost", "port": "2181"}]"""
+      val props = Map("zookeeper.connect" -> JsoneyString(conn), "zookeeper.path" -> "/test")
+      val input = new KafkaInput(props)
+
+      input.getZkConnectionConfs(props, "zookeeper.connect", "localhost", "2181", "/test") should
+        be("zookeeper.connect", "localhost:2181/test")
     }
 
     "return a chain (zookeper:conection , host:port,host:port,host:port)" in {
       val conn =
         """[{"host": "localhost", "port": "2181"},{"host": "localhost", "port": "2181"},
           |{"host": "localhost", "port": "2181"}]""".stripMargin
-      val input = new KafkaInput(Map("zookeeper.connect" -> JsoneyString(conn)))
-      input.getZkConnectionConfs("zookeeper.connect", "localhost", "2181") should
+      val props = Map("zookeeper.connect" -> JsoneyString(conn))
+      val input = new KafkaInput(props)
+
+      input.getZkConnectionConfs(props, "zookeeper.connect", "localhost", "2181", "") should
         be("zookeeper.connect", "localhost:2181,localhost:2181,localhost:2181")
+    }
+
+    "return a chain (zookeper:conection , host:port,host:port,host:port, zookeeper.path:path)" in {
+      val conn =
+        """[{"host": "localhost", "port": "2181"},{"host": "localhost", "port": "2181"},
+          |{"host": "localhost", "port": "2181"}]""".stripMargin
+      val props = Map("zookeeper.connect" -> JsoneyString(conn), "zookeeper.path" -> "/test")
+      val input = new KafkaInput(props)
+
+      input.getZkConnectionConfs(props, "zookeeper.connect", "localhost", "2181", "/test") should
+        be("zookeeper.connect", "localhost:2181,localhost:2181,localhost:2181/test")
     }
 
     "return a chain with default port (zookeper:conection , host: defaultport)" in {
       val conn =
         """[{"host": "localhost"}]"""
-      val input = new KafkaInput(Map("zookeeper.connect" -> JsoneyString(conn)))
-      input.getZkConnectionConfs("zookeeper.connect", "localhost", "2181") should
+      val props = Map("zookeeper.connect" -> JsoneyString(conn))
+      val input = new KafkaInput(props)
+
+      input.getZkConnectionConfs(props, "zookeeper.connect", "localhost", "2181", "") should
         be("zookeeper.connect", "localhost:2181")
     }
 
-    "return a chain with default host (zookeper:conection , defaultHost: port)" in {
+    "return a chain with default port (zookeper:conection , host: defaultport, zookeeper.path:path)" in {
       val conn =
-        """[{"port": "2181"}]"""
-      val input = new KafkaInput(Map("zookeeper.connect" -> JsoneyString(conn)))
-      input.getZkConnectionConfs("zookeeper.connect", "localhost", "2181") should
-        be("zookeeper.connect", "localhost:2181")
+        """[{"host": "localhost"}]"""
+      val props = Map("zookeeper.connect" -> JsoneyString(conn))
+      val input = new KafkaInput(props)
+
+      input.getZkConnectionConfs(props, "zookeeper.connect", "localhost", "2181", "/test") should
+        be("zookeeper.connect", "localhost:2181/test")
     }
 
-    "return a chain with default host and default porty (zookeeper.connect: , defaultHost: defaultport)" in {
+    "return a chain with default host and default porty (zookeeper.connect: ," +
+      "defaultHost: defaultport," +
+      "zookeeper.path:path)" in {
       val conn =
         """[{}]"""
-      val input = new KafkaInput(Map("zookeeper.connect" -> JsoneyString(conn)))
-      input.getZkConnectionConfs("zookeeper.connect", "localhost", "2181") should
+      val props = Map("zookeeper.connect" -> JsoneyString(conn))
+      val input = new KafkaInput(props)
+
+      input.getZkConnectionConfs(props, "zookeeper.connect", "localhost", "2181", "") should
         be("zookeeper.connect", "localhost:2181")
     }
   }

--- a/web/src/data-templates/input.json
+++ b/web/src/data-templates/input.json
@@ -212,6 +212,15 @@
       ]
       },
       {
+        "propertyId": "zookeeper.path",
+        "propertyName": "_ZOOKEEPER_PATH_",
+        "propertyType": "text",
+        "regexp": "",
+        "required": false,
+        "tooltip": "",
+        "qa": "fragment-details-zookeeper-path"
+      },
+      {
         "propertyId": "kafkaParams.group.id",
         "propertyName": "_GROUP_ID_",
         "propertyType": "text",
@@ -333,6 +342,50 @@
           "qa": "fragment-details-kafkadirect-topic"
         }
       ]
+      },
+      {
+        "propertyId": "zookeeper.connect",
+        "propertyName": "_ZOOKEEPER_CONNECT_",
+        "propertyType": "list",
+        "default": "",
+        "required": false,
+        "hidden": false,
+        "limit": 0,
+        "tooltip": "",
+        "qa": "fragment-details-kafka-zookeeper-connect",
+        "fields": [
+          {
+            "propertyId": "host",
+            "propertyName": "_ZOOKEEPER_HOST_",
+            "propertyType": "text",
+            "regexp": "((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(((?![0-9]+$)(?!.*-$)(?!-)[a-zA-Z0-9-]{2,63}))",
+            "default": "",
+            "required": false,
+            "tooltip": "Zookeeper's address.",
+            "hidden": false,
+            "qa": "fragment-details-kafka-host"
+          },
+          {
+            "propertyId": "port",
+            "propertyName": "_ZOOKEEPER_PORT_",
+            "propertyType": "text",
+            "regexp": "(0|([1-9]\\d{0,3}|[1-5]\\d{4}|[6][0-5][0-5]([0-2]\\d|[3][0-5])))",
+            "default": "",
+            "required": false,
+            "tooltip": "Zookeeper's port.",
+            "hidden": false,
+            "qa": "fragment-details-kafka-port"
+          }
+        ]
+      },
+      {
+        "propertyId": "zookeeper.path",
+        "propertyName": "_ZOOKEEPER_PATH_",
+        "propertyType": "text",
+        "regexp": "",
+        "required": false,
+        "tooltip": "",
+        "qa": "fragment-details-zookeeper-path"
       }
     ]
   },

--- a/web/src/data-templates/output.json
+++ b/web/src/data-templates/output.json
@@ -623,6 +623,50 @@
       "qa": "fragment-details-kafka-batch-num-messages"
     },
     {
+      "propertyId": "zookeeper.connect",
+      "propertyName": "_ZOOKEEPER_CONNECT_",
+      "propertyType": "list",
+      "default": "",
+      "required": false,
+      "hidden": false,
+      "limit": 0,
+      "tooltip": "",
+      "qa": "fragment-details-kafka-zookeeper-connect",
+      "fields": [
+        {
+          "propertyId": "host",
+          "propertyName": "_ZOOKEEPER_HOST_",
+          "propertyType": "text",
+          "regexp": "((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))|(((?![0-9]+$)(?!.*-$)(?!-)[a-zA-Z0-9-]{2,63}))",
+          "default": "",
+          "required": false,
+          "tooltip": "Zookeeper's address.",
+          "hidden": false,
+          "qa": "fragment-details-kafka-host"
+        },
+        {
+          "propertyId": "port",
+          "propertyName": "_ZOOKEEPER_PORT_",
+          "propertyType": "text",
+          "regexp": "(0|([1-9]\\d{0,3}|[1-5]\\d{4}|[6][0-5][0-5]([0-2]\\d|[3][0-5])))",
+          "default": "",
+          "required": false,
+          "tooltip": "Zookeeper's port.",
+          "hidden": false,
+          "qa": "fragment-details-kafka-port"
+        }
+      ]
+    },
+    {
+      "propertyId": "zookeeper.path",
+      "propertyName": "_ZOOKEEPER_PATH_",
+      "propertyType": "text",
+      "regexp": "",
+      "required": false,
+      "tooltip": "",
+      "qa": "fragment-details-zookeeper-path"
+    },
+    {
       "propertyId": "kafkaProperties",
       "propertyName": "_KAFKA_PROPERTIES_",
       "propertyType": "list",

--- a/web/src/languages/en-US.json
+++ b/web/src/languages/en-US.json
@@ -273,6 +273,7 @@
   "_REQUIRED_ACKS_": "Required ACKs",
   "_KAFKA_HOST_": "Zookeeper host",
   "_KAFKA_PORT_": "Kafka port",
+  "_ZOOKEEPER_PATH_": "Zookeeper path",
   "_PRODUCER_TYPE_": "Producer type (sync/async)",
   "_BATCH_NUM_MESSAGES_": "Batch num messages",
   "_FILTER_BY_TYPE_": "Filter by type",


### PR DESCRIPTION
**As** a user
**I want** to change the default zookeeper path in Kafka input and output
**So I** can have Kafka persisting the offset in other folder than the default

**Given** a Kafka configured with a zookeeper offset path different from the default
**When** launching a policy with a Kafka input configured
**Then** the policy should aggregate events

**Given** a Kafka configured with a zookeeper offset path different from the default
**When** launching a policy with a Kafka Direct input configured
**Then** the policy should aggregate events

**Given** a Kafka configured with a zookeeper offset path different from the default
**When** launching a policy with a Kafka output configured
**Then** the policy should aggregate events

Doc updated:
https://stratio.atlassian.net/wiki/display/SPARKTA/Inputs
https://stratio.atlassian.net/wiki/display/SPARKTA/Outputs