### PR TITLE
[SPARTA-901]Creation of /config endpoint in Sparta Backend

### DIFF
--- a/dist/src/main/resources/reference.conf
+++ b/dist/src/main/resources/reference.conf
@@ -70,6 +70,9 @@ sparta.config.autoDeleteCheckpoint = true
 # Add time to checkpoint path when run policies in cluster mode is necessary HDFS configuration
 sparta.config.addTimeToCheckpointPath = false
 
+# FRONTEND
+sparta.config.frontend.timeout = 5000
+
 # HDFS
 
 # The hadoop user name could be configured by two ways:

--- a/docker/sparta-server-utils.sh
+++ b/docker/sparta-server-utils.sh
@@ -202,6 +202,10 @@ function configOptions() {
  fi
  sed -i "s|.*sparta.config.addTimeToCheckpointPath.*|sparta.config.addTimeToCheckpointPath = ${SPARTA_ADD_TIME_TO_CHECKPOINT}|" ${SPARTA_CONF_FILE}
 
+ if [[ -v FRONTEND_TIMEOUT ]] && [ ${#FRONTEND_TIMEOUT} != 0 ]; then
+ sed -i "s|.*sparta.config.frontend.timeout.*|sparta.config.frontend.timeout = ${FRONTEND_TIMEOUT}|" ${SPARTA_CONF_FILE}
+ fi
+
 }
 
 function localSparkOptions() {

--- a/serving-api/src/main/resources/reference.conf
+++ b/serving-api/src/main/resources/reference.conf
@@ -70,6 +70,9 @@ sparta.config.autoDeleteCheckpoint = true
 # Add time to checkpoint path when run policies in cluster mode is necessary HDFS configuration
 sparta.config.addTimeToCheckpointPath = false
 
+# FRONTEND
+sparta.config.frontend.timeout = 5000
+
 # HDFS
 
 # The hadoop user name could be configured by two ways:

--- a/serving-api/src/main/scala/com/stratio/sparta/serving/api/actor/ConfigActor.scala
+++ b/serving-api/src/main/scala/com/stratio/sparta/serving/api/actor/ConfigActor.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stratio.sparta.serving.api.actor
+
+import akka.actor.{Actor, _}
+import akka.event.slf4j.SLF4JLogging
+import com.stratio.sparta.serving.api.actor.ConfigActor._
+import com.stratio.sparta.serving.api.constants.HttpConstant
+import com.stratio.sparta.serving.core.config.SpartaConfig
+import com.stratio.sparta.serving.core.constants.AppConstant
+import com.stratio.sparta.serving.core.models.SpartaSerializer
+import com.stratio.sparta.serving.core.models.frontend.FrontendConfiguration
+import spray.httpx.Json4sJacksonSupport
+
+import scala.util.Try
+
+class ConfigActor extends Actor with SLF4JLogging with Json4sJacksonSupport with SpartaSerializer {
+
+  val apiPath = HttpConstant.ConfigPath
+
+  override def receive: Receive = {
+    case FindAll => findFrontendConfig()
+    case _ => log.info("Unrecognized message in ConfigActor")
+  }
+
+  def findFrontendConfig(): Unit = {
+    sender ! ConfigResponse(retrieveStringConfig())
+  }
+
+  def retrieveStringConfig(): FrontendConfiguration = {
+      FrontendConfiguration(
+        Try(SpartaConfig.getFrontendConfig.get
+          .getInt("timeout")).getOrElse(AppConstant.DefaultFrontEndTimeout))
+  }
+
+}
+
+object ConfigActor {
+  object FindAll
+  case class ConfigResponse(frontendConfiguration:FrontendConfiguration)
+}

--- a/serving-api/src/main/scala/com/stratio/sparta/serving/api/actor/ControllerActor.scala
+++ b/serving-api/src/main/scala/com/stratio/sparta/serving/api/actor/ControllerActor.scala
@@ -103,7 +103,7 @@ class ControllerActor(actorsMap: Map[String, ActorRef], curatorFramework: Curato
     serviceRoutes.fragmentRoute(user) ~ serviceRoutes.policyContextRoute(user) ~
       serviceRoutes.executionRoute(user) ~ serviceRoutes.policyRoute(user) ~ serviceRoutes.appStatusRoute ~
       serviceRoutes.pluginsRoute(user) ~ serviceRoutes.driversRoute(user) ~
-      serviceRoutes.swaggerRoute
+      serviceRoutes.configRoute(user) ~ serviceRoutes.swaggerRoute
   }
 
   private def webRoutes: Route =
@@ -141,6 +141,8 @@ class ServiceRoutes(actorsMap: Map[String, ActorRef], context: ActorContext, cur
   def pluginsRoute(user: Option[LoggedUser]): Route = pluginsService.routes(user)
 
   def driversRoute(user: Option[LoggedUser]): Route = driversService.routes(user)
+
+  def configRoute(user: Option[LoggedUser]): Route = configService.routes(user)
 
   def swaggerRoute: Route = swaggerService.routes
 
@@ -203,4 +205,12 @@ class ServiceRoutes(actorsMap: Map[String, ActorRef], context: ActorContext, cur
       case None => "/"
     }
   }
+
+  private val configService = new ConfigHttpService {
+    override implicit val actors: Map[String, ActorRef] = actorsMap
+    override val supervisor: ActorRef = actorsMap(AkkaConstant.ConfigActorName)
+    override val actorRefFactory: ActorRefFactory = context
+  }
+
+
 }

--- a/serving-api/src/main/scala/com/stratio/sparta/serving/api/helpers/SpartaHelper.scala
+++ b/serving-api/src/main/scala/com/stratio/sparta/serving/api/helpers/SpartaHelper.scala
@@ -54,6 +54,7 @@ object SpartaHelper extends SLF4JLogging with SSLSupport {
       val launcherActor = system.actorOf(Props(new LauncherActor(scService, curatorFramework)), LauncherActorName)
       val pluginActor = system.actorOf(Props(new PluginActor()), PluginActorName)
       val driverActor = system.actorOf(Props(new DriverActor()), DriverActorName)
+      val configActor = system.actorOf(Props(new ConfigActor()), ConfigActorName)
       val actors = Map(
         StatusActorName -> statusActor,
         FragmentActorName -> fragmentActor,
@@ -61,7 +62,8 @@ object SpartaHelper extends SLF4JLogging with SSLSupport {
         LauncherActorName -> launcherActor,
         PluginActorName -> pluginActor,
         DriverActorName -> driverActor,
-        ExecutionActorName -> executionActor
+        ExecutionActorName -> executionActor,
+        ConfigActorName -> configActor
       )
       val controllerActor = system.actorOf(Props(new ControllerActor(actors, curatorFramework)), ControllerActorName)
 

--- a/serving-api/src/main/scala/com/stratio/sparta/serving/api/service/http/ConfigHttpService.scala
+++ b/serving-api/src/main/scala/com/stratio/sparta/serving/api/service/http/ConfigHttpService.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stratio.sparta.serving.api.service.http
+
+import javax.ws.rs.Path
+
+import akka.pattern.ask
+import com.stratio.sparta.serving.api.actor.ConfigActor._
+import com.stratio.sparta.serving.api.constants.HttpConstant
+import com.stratio.sparta.serving.core.models.SpartaSerializer
+import com.stratio.sparta.serving.core.models.dto.LoggedUser
+import com.wordnik.swagger.annotations.{Api, ApiOperation, ApiResponse, ApiResponses}
+import spray.routing.Route
+
+
+@Api(value = HttpConstant.ConfigPath, description = "Operations on Sparta Configuration")
+trait ConfigHttpService extends BaseHttpService with SpartaSerializer {
+
+  override def routes(user: Option[LoggedUser] = None): Route = getAll(user)
+
+  @Path("")
+  @ApiOperation(value = "Retrieve all frontend configuration settings",
+    notes = "Returns configuration value for frontend",
+    httpMethod = "GET")
+  @ApiResponses(
+    Array(new ApiResponse(code = HttpConstant.NotFound,
+      message = HttpConstant.NotFoundMessage)))
+  def getAll(user: Option[LoggedUser]): Route = {
+    path(HttpConstant.ConfigPath) {
+      get {
+        complete {
+          for {
+            response <- (supervisor ? FindAll).mapTo[ConfigResponse]
+          } yield response match {
+            case ConfigResponse(config) => config
+          }
+        }
+      }
+    }
+  }
+
+}

--- a/serving-api/src/main/scala/com/stratio/sparta/serving/api/service/http/SwaggerService.scala
+++ b/serving-api/src/main/scala/com/stratio/sparta/serving/api/service/http/SwaggerService.scala
@@ -30,7 +30,8 @@ trait SwaggerService extends SwaggerHttpService {
     typeOf[PluginsHttpService],
     typeOf[DriverHttpService],
     typeOf[AppStatusHttpService],
-    typeOf[ExecutionHttpService]
+    typeOf[ExecutionHttpService],
+    typeOf[ConfigHttpService]
   )
 
   override def apiVersion: String = "1.0"

--- a/serving-api/src/test/resources/reference.conf
+++ b/serving-api/src/test/resources/reference.conf
@@ -54,6 +54,8 @@ sparta.config.checkpointPath = "/tmp/sparta/checkpoint"
 # Auto delete checkpoint when run policies in cluster mode is necessary HDFS configuration
 sparta.config.autoDeleteCheckpoint = false
 
+# FRONTEND
+sparta.config.frontend.timeout = 5000
 
 # HDFS
 # The hadoop user name could be configured by two ways:

--- a/serving-api/src/test/scala/com/stratio/sparta/serving/api/actor/ControllerActorTest.scala
+++ b/serving-api/src/test/scala/com/stratio/sparta/serving/api/actor/ControllerActorTest.scala
@@ -47,6 +47,7 @@ class ControllerActorTest(_system: ActorSystem) extends TestKit(_system)
   val sparkStreamingContextActor = _system.actorOf(
     Props(new LauncherActor(streamingContextService, curatorFramework)))
   val pluginActor = _system.actorOf(Props(new PluginActor()))
+  val configActor = _system.actorOf(Props(new ConfigActor()))
 
   def this() =
     this(ActorSystem("ControllerActorSpec", SpartaConfig.daemonicAkkaConfig))
@@ -57,7 +58,8 @@ class ControllerActorTest(_system: ActorSystem) extends TestKit(_system)
     AkkaConstant.PolicyActorName -> policyActor,
     AkkaConstant.LauncherActorName -> sparkStreamingContextActor,
     AkkaConstant.PluginActorName -> pluginActor,
-    AkkaConstant.ExecutionActorName -> executionActor
+    AkkaConstant.ExecutionActorName -> executionActor,
+    AkkaConstant.ConfigActorName -> configActor
   )
 
   override def afterAll {

--- a/serving-api/src/test/scala/com/stratio/sparta/serving/api/service/http/ConfigHttpServiceTest.scala
+++ b/serving-api/src/test/scala/com/stratio/sparta/serving/api/service/http/ConfigHttpServiceTest.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2015 Stratio (http://stratio.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.stratio.sparta.serving.api.service.http
+
+import akka.actor.ActorRef
+import akka.testkit.TestProbe
+import com.stratio.sparta.serving.api.actor.ConfigActor
+import com.stratio.sparta.serving.api.actor.ConfigActor._
+import com.stratio.sparta.serving.api.constants.HttpConstant
+import com.stratio.sparta.serving.core.config.{SpartaConfig, SpartaConfigFactory}
+import com.stratio.sparta.serving.core.constants.AkkaConstant
+import com.stratio.sparta.serving.core.models.dto.LoggedUserConstant
+import com.stratio.sparta.serving.core.models.frontend.FrontendConfiguration
+import org.junit.runner.RunWith
+import org.scalatest.WordSpec
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class ConfigHttpServiceTest extends WordSpec
+  with ConfigHttpService
+  with HttpServiceBaseTest{
+
+  val configActorTestProbe = TestProbe()
+
+  val dummyUser = Some(LoggedUserConstant.AnonymousUser)
+
+  override implicit val actors: Map[String, ActorRef] = Map(
+    AkkaConstant.ConfigActorName -> configActorTestProbe.ref
+  )
+
+  override val supervisor: ActorRef = testProbe.ref
+
+  override def beforeEach(): Unit = {
+    SpartaConfig.initMainConfig(Option(localConfig), SpartaConfigFactory(localConfig))
+  }
+
+  "ConfigHttpService.FindAll" should {
+    "retrieve a FrontendConfiguration item" in {
+      startAutopilot(ConfigResponse(retrieveStringConfig()))
+      Get(s"/${HttpConstant.ConfigPath}") ~> routes(dummyUser) ~> check {
+        testProbe.expectMsgType[ConfigActor.FindAll.type]
+        responseAs[FrontendConfiguration] should equal(retrieveStringConfig())
+      }
+    }
+  }
+
+}

--- a/serving-api/src/test/scala/com/stratio/sparta/serving/api/service/http/HttpServiceBaseTest.scala
+++ b/serving-api/src/test/scala/com/stratio/sparta/serving/api/service/http/HttpServiceBaseTest.scala
@@ -20,8 +20,11 @@ import akka.testkit.TestActor.AutoPilot
 import akka.testkit.{TestActor, TestProbe}
 import com.stratio.sparta.sdk.pipeline.aggregation.cube.DimensionType
 import com.stratio.sparta.sdk.pipeline.input.Input
+import com.stratio.sparta.serving.api.actor.ConfigActor.ConfigResponse
+import com.stratio.sparta.serving.core.constants.AppConstant
 import com.stratio.sparta.serving.core.models.SpartaSerializer
 import com.stratio.sparta.serving.core.models.enumerators.PolicyStatusEnum
+import com.stratio.sparta.serving.core.models.frontend.FrontendConfiguration
 import com.stratio.sparta.serving.core.models.policy._
 import com.stratio.sparta.serving.core.models.policy.cube.{CubeModel, DimensionModel, OperatorModel}
 import com.stratio.sparta.serving.core.models.policy.fragment.FragmentElementModel
@@ -66,6 +69,8 @@ trait HttpServiceBaseTest extends WordSpec
     """.stripMargin)
 
   // XXX Protected methods.
+  protected def retrieveStringConfig(): FrontendConfiguration =
+    FrontendConfiguration(AppConstant.DefaultFrontEndTimeout)
 
   protected def getFragmentModel(id: Option[String]): FragmentElementModel =
     new FragmentElementModel(id, "input", "name", "description", "shortDescription",

--- a/serving-core/src/main/scala/com/stratio/sparta/serving/core/config/SpartaConfig.scala
+++ b/serving-core/src/main/scala/com/stratio/sparta/serving/core/config/SpartaConfig.scala
@@ -86,6 +86,8 @@ object SpartaConfig extends SLF4JLogging {
 
   def getZookeeperConfig: Option[Config] = mainConfig.flatMap(config => getOptionConfig(ConfigZookeeper, config))
 
+  def getFrontendConfig: Option[Config] = mainConfig.flatMap(config => getOptionConfig(ConfigFrontend,config))
+
   def getSprayConfig: Option[Config] = SpartaConfigFactory().getConfig(ConfigSpray)
 
   def initOptionalConfig(node: String,

--- a/serving-core/src/main/scala/com/stratio/sparta/serving/core/constants/AkkaConstant.scala
+++ b/serving-core/src/main/scala/com/stratio/sparta/serving/core/constants/AkkaConstant.scala
@@ -34,6 +34,7 @@ object AkkaConstant {
   val StatusActorName = "statusActor"
   val MarathonAppActorName = "marathonAppActor"
   val UpDownMarathonActor = "upDownMarathonActor"
+  val ConfigActorName = "configurationActor"
 
   val DefaultTimeout = 15
 

--- a/serving-core/src/main/scala/com/stratio/sparta/serving/core/constants/AppConstant.scala
+++ b/serving-core/src/main/scala/com/stratio/sparta/serving/core/constants/AppConstant.scala
@@ -31,6 +31,7 @@ object AppConstant {
   val ConfigDetail = "config"
   val ConfigSpray = "spray.can.server"
   val ConfigZookeeper = "zookeeper"
+  val ConfigFrontend = "config.frontend"
 
   //Config Options
   val ExecutionMode = "executionMode"
@@ -47,6 +48,7 @@ object AppConstant {
   val DefaultDriverLocation = "provided"
   val PluginsPackageLocation = "pluginPackageLocation"
   val DefaultPluginsPackageLocation = "/opt/sds/plugins/"
+  val DefaultFrontEndTimeout = 10000
 
   //killing options
   val AwaitPolicyChangeStatus = "awaitPolicyChangeStatus"

--- a/serving-core/src/main/scala/com/stratio/sparta/serving/core/models/frontend/FrontendConfiguration.scala
+++ b/serving-core/src/main/scala/com/stratio/sparta/serving/core/models/frontend/FrontendConfiguration.scala
@@ -13,21 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.stratio.sparta.serving.api.constants
+package com.stratio.sparta.serving.core.models.frontend
 
-object HttpConstant  {
-  final val SpartaRootPath = "sparta"
-  final val DriverPath = "driver"
-  final val PluginsPath = "plugins"
-  final val FragmentPath = "fragment"
-  final val TemplatePath = "template"
-  final val PolicyPath = "policy"
-  final val PolicyContextPath = "policyContext"
-  final val ExecutionsPath = "executions"
-  final val SwaggerPath = "swagger"
-  final val ContextsPath = "contexts"
-  final val ConfigPath = "config"
-  final val AppStatus= "status"
-  final val NotFound = 400
-  final val NotFoundMessage = "Not Found"
-}
+case class FrontendConfiguration(timeout: Int)

--- a/serving-core/src/test/resources/reference.conf
+++ b/serving-core/src/test/resources/reference.conf
@@ -82,6 +82,8 @@ sparta.config.autoDeleteCheckpoint = false
 # Add time to checkpoint path when run policies in cluster mode is necessary HDFS configuration
 sparta.config.addTimeToCheckpointPath = false
 
+# FRONTEND
+sparta.config.frontend.timeout = 5000
 
 # HDFS
 


### PR DESCRIPTION
To create the /config endpoint, the following things have been added:
* service ConfigHttpService (and related Test class)
* actor ConfigActor
* FRONTEND_TIMEOUT environment variable
* sparta.config.frontend.timeout option in reference.conf
